### PR TITLE
Skip migrations when deploying because oracle

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -5,7 +5,7 @@ require 'capistrano/setup'
 require 'capistrano/deploy'
 require 'dlss/capistrano'
 require 'capistrano/bundler'
-require 'capistrano/rails'
+require 'capistrano/rails/assets'
 require 'capistrano/passenger'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined


### PR DESCRIPTION
We only want to use migrations locally for testing. Instead of loading up `capistrano/rails`, which includes both migrations and assets, we're only loading up `capistrano/rails/assets`
