### PR TITLE
Don't throw error for pending migrations

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
   config.active_support.deprecation = :log
 
   # Raise an error on page load if there are pending migrations.
-  config.active_record.migration_error = :page_load
+  config.active_record.migration_error = false
 
 
   # Raises error for missing translations


### PR DESCRIPTION
We want migrations for testing only. Capistrano is set up to not run migrations, but in this version of rails, the app throws an error when there are pending migrations. This silences the error.
