### PR TITLE
Add unicorn_policies for forms

### DIFF
--- a/app/models/unicorn_policy.rb
+++ b/app/models/unicorn_policy.rb
@@ -1,0 +1,19 @@
+###
+#  Class to connect to the UNICORN_POLICIES table in Symphony
+###
+class UnicornPolicy < ActiveRecord::Base
+  self.table_name = 'unicorn_policies'
+  self.inheritance_column = nil
+
+  def self.libraries
+    where(type: 'LIBR')
+  end
+
+  def self.item_types
+    where(type: 'ITYP')
+  end
+
+  def self.locations
+    where(type: 'LOCN')
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
 
     get 'batch_record_updates/errors_for_batch' => 'batch_record_updates#errors_for_batch'
     get 'batch_record_updates/errors_for_batch/:batch_number' => 'batch_record_updates#errors_for_batch'
-    
+
     get 'transfer_request_form' => 'batch_record_updates#transfer_request_form'
     get 'withdraw_some_items' => 'batch_record_updates#withdraw_some_items'
     get 'change_home_location' => 'batch_record_updates#change_home_location'

--- a/db/migrate/20160509190330_create_unicorn_policies.rb
+++ b/db/migrate/20160509190330_create_unicorn_policies.rb
@@ -1,0 +1,14 @@
+class CreateUnicornPolicies < ActiveRecord::Migration
+  def change
+    create_table :unicorn_policies do |t|
+      t.string :type
+      t.integer :policy_num
+      t.string :name
+      t.string :description
+      t.string :shadowed
+      t.string :destination
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160504234929) do
+ActiveRecord::Schema.define(version: 20160509190330) do
 
   create_table "authorized_user", force: :cascade do |t|
     t.string   "user_id"
@@ -83,6 +83,17 @@ ActiveRecord::Schema.define(version: 20160504234929) do
     t.string "call_num"
     t.string "shelving_key"
     t.string "msg"
+  end
+
+  create_table "unicorn_policies", force: :cascade do |t|
+    t.string   "type"
+    t.integer  "policy_num"
+    t.string   "name"
+    t.string   "description"
+    t.string   "shadowed"
+    t.string   "destination"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
   end
 
 end

--- a/spec/factories/unicorn_policies.rb
+++ b/spec/factories/unicorn_policies.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :unicorn_policy do
+    type 'LIBR'
+    policy_num 1
+    name 'GREEN'
+    description ''
+    shadowed ''
+    destination ''
+  end
+end

--- a/spec/models/unicorn_policy_spec.rb
+++ b/spec/models/unicorn_policy_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe UnicornPolicy, type: :model do
+  it 'has a valid factory' do
+    expect(FactoryGirl.create(:unicorn_policy)).to be_valid
+  end
+
+  it 'returns libraries' do
+    FactoryGirl.create(:unicorn_policy)
+    expect(UnicornPolicy.libraries.first.type).to eq('LIBR')
+  end
+
+  it 'returns itypes' do
+    FactoryGirl.create(:unicorn_policy, type: 'ITYP')
+    expect(UnicornPolicy.item_types.first.type).to eq('ITYP')
+  end
+
+  it 'returns locations' do
+    FactoryGirl.create(:unicorn_policy, type: 'LOCN')
+    expect(UnicornPolicy.locations.first.type).to eq('LOCN')
+  end
+end


### PR DESCRIPTION
Various forms need to set libraries, item types and locations parameters, pulled from unicorn_policies
