### PR TITLE
create batch and updates for change item type

### DIFF
--- a/app/controllers/change_item_types_controller.rb
+++ b/app/controllers/change_item_types_controller.rb
@@ -6,11 +6,11 @@ class ChangeItemTypesController < ApplicationController
   end
 
   def create
-    @change_item_type = ChangeItemType.new(params[:change_item_type])
-    if @change_item_type.valid?
-      array_of_item_ids = @change_item_type.parse_uploaded_file
-      UniUpdates.where(item_id: array_of_item_ids).update_all(curr_lib: @change_item_type.current_library,
-                                                              new_itype: @change_item_type.new_item_type)
+    change_item_type = ChangeItemType.new(params[:change_item_type])
+    if change_item_type.valid?
+      array_of_item_ids = change_item_type.parse_uploaded_file
+      uni_updates_batch = UniUpdatesBatch.create_item_type_batch(params)
+      UniUpdates.create_item_type_updates(array_of_item_ids, uni_updates_batch)
       flash[:notice] = 'Batch updated!'
       redirect_to root_url
     else

--- a/app/models/change_item_type.rb
+++ b/app/models/change_item_type.rb
@@ -3,7 +3,21 @@
 ###
 class ChangeItemType
   include ActiveModel::Model
-  attr_accessor :current_library, :new_item_type, :item_ids, :email, :comments
+  attr_accessor :current_library
+  attr_accessor :new_item_type
+  attr_accessor :item_ids
+  attr_accessor :email
+  attr_accessor :comments
+  attr_accessor :batch_date
+  attr_accessor :user_name
+  attr_accessor :action
+  attr_accessor :priority
+  attr_accessor :export_yn
+  attr_accessor :new_lib
+  attr_accessor :new_homeloc
+  attr_accessor :new_curloc
+  attr_accessor :check_bc_first
+
   validates :current_library, :new_item_type, :item_ids, presence: true
 
   def parse_uploaded_file

--- a/app/models/uni_updates.rb
+++ b/app/models/uni_updates.rb
@@ -3,6 +3,23 @@
 ###
 class UniUpdates < ActiveRecord::Base
   self.table_name = 'uni_updates'
-  self.primary_key = 'batch_id'
-  belongs_to :uni_updates_batch, foreign_key: 'batch_id'
+  belongs_to :uni_updates_batch, foreign_key: 'batch_id', class_name: UniUpdatesBatch
+
+  # rubocop:disable Metrics/MethodLength
+  def self.create_item_type_updates(array_of_item_ids, uni_updates_batch)
+    hashes_for_updates = []
+    array_of_item_ids.each do |item_id|
+      hashes_for_updates << {  batch_id: uni_updates_batch.batch_id,
+                               export_yn: uni_updates_batch.export_yn,
+                               priority: uni_updates_batch.priority,
+                               action: uni_updates_batch.action,
+                               item_id: item_id,
+                               curr_lib: uni_updates_batch.orig_lib,
+                               new_itype: uni_updates_batch.new_itype,
+                               check_bc_first: uni_updates_batch.check_bc_first
+                            }
+    end
+    UniUpdates.create(hashes_for_updates)
+  end
+  # rubocop:enable Metrics/MethodLength
 end

--- a/app/models/uni_updates_batch.rb
+++ b/app/models/uni_updates_batch.rb
@@ -5,4 +5,19 @@ class UniUpdatesBatch < ActiveRecord::Base
   self.table_name = 'uni_updates_batch'
   self.primary_key = 'batch_id'
   has_many :uni_updates, foreign_key: 'batch_id', class_name: UniUpdates
+
+  # rubocop:disable Metrics/AbcSize
+  def self.create_item_type_batch(params)
+    create(batch_date: params[:change_item_type][:batch_date],
+           user_name: params[:change_item_type][:user_name],
+           user_email: params[:change_item_type][:email],
+           orig_lib: params[:change_item_type][:current_library],
+           action: params[:change_item_type][:action],
+           priority: params[:change_item_type][:priority],
+           export_yn: params[:change_item_type][:export_yn],
+           new_itype: params[:change_item_type][:new_item_type],
+           check_bc_first: params[:change_item_type][:check_bc_first],
+           comments: params[:change_item_type][:comments])
+  end
+  # rubocop:enable Metrics/AbcSize
 end

--- a/app/views/change_item_types/new.html.erb
+++ b/app/views/change_item_types/new.html.erb
@@ -39,6 +39,15 @@
       <%= f.text_area 'comments', class: 'form-control' %>
     </div>
   </div>
-  <div><%= f.submit 'Update batch', class: 'btn btn-primary' %></div><br/>
+  <%= f.hidden_field :batch_date, value: Time.now %>
+  <%= f.hidden_field :user_name, value: current_user.user_id %>
+  <%= f.hidden_field :action, value: 'UPDITEMTYPE' %>
+  <%= f.hidden_field :priority, value: 3 %>
+  <%= f.hidden_field :export_yn, value: 'SocI' %>
+  <!-- new_lib -->
+  <!-- new_homeloc -->
+  <!-- new_curloc -->
+  <%= f.hidden_field :check_bc_first, value: 'N' %>
+  <div><%= f.submit 'Upload batch', class: 'btn btn-primary' %></div><br/>
   <div class="btn-group"><%= main_menu_button %></div>
 <% end %>

--- a/db/migrate/20160502230655_create_uni_updates_batch.rb
+++ b/db/migrate/20160502230655_create_uni_updates_batch.rb
@@ -1,7 +1,6 @@
 class CreateUniUpdatesBatch < ActiveRecord::Migration
   def change
-    create_table :uni_updates_batch do |t|
-      t.integer :batch_id
+    create_table :uni_updates_batch, :primary_key => :batch_id do |t|
       t.datetime :batch_date
       t.string :user_name
       t.string :user_email

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -54,8 +54,7 @@ ActiveRecord::Schema.define(version: 20160509190330) do
     t.datetime "updated_at",     null: false
   end
 
-  create_table "uni_updates_batch", force: :cascade do |t|
-    t.integer  "batch_id"
+  create_table "uni_updates_batch", primary_key: "batch_id", force: :cascade do |t|
     t.datetime "batch_date"
     t.string   "user_name"
     t.string   "user_email"


### PR DESCRIPTION
This also fixes the bug where a `UniUpdatesBatch` object created via a form was not getting `batch_id` assigned, but was via the console.
