### PR TITLE
Use instance variables in form controllers

### DIFF
--- a/app/controllers/change_item_types_controller.rb
+++ b/app/controllers/change_item_types_controller.rb
@@ -6,9 +6,9 @@ class ChangeItemTypesController < ApplicationController
   end
 
   def create
-    change_item_type = ChangeItemType.new(params[:change_item_type])
-    if change_item_type.valid?
-      array_of_item_ids = change_item_type.parse_uploaded_file
+    @change_item_type = ChangeItemType.new(params[:change_item_type])
+    if @change_item_type.valid?
+      array_of_item_ids = @change_item_type.parse_uploaded_file
       @uni_updates_batch = UniUpdatesBatch.create_item_type_batch(params)
       UniUpdates.create_for_batch(array_of_item_ids, @uni_updates_batch)
       flash[:notice] = 'Batch uploaded!'

--- a/app/controllers/transfer_items_controller.rb
+++ b/app/controllers/transfer_items_controller.rb
@@ -6,9 +6,9 @@ class TransferItemsController < ApplicationController
   end
 
   def create
-    transfer_item = TransferItem.new(params[:transfer_item])
-    if transfer_item.valid?
-      array_of_item_ids = transfer_item.parse_uploaded_file
+    @transfer_item = TransferItem.new(params[:transfer_item])
+    if @transfer_item.valid?
+      array_of_item_ids = @transfer_item.parse_uploaded_file
       @uni_updates_batch = UniUpdatesBatch.create_transfer_item_batch(params)
       UniUpdates.create_for_batch(array_of_item_ids, @uni_updates_batch)
       redirect_valid

--- a/app/controllers/withdraw_items_controller.rb
+++ b/app/controllers/withdraw_items_controller.rb
@@ -6,9 +6,9 @@ class WithdrawItemsController < ApplicationController
   end
 
   def create
-    withdraw_item = WithdrawItem.new(params[:withdraw_item])
-    if withdraw_item.valid?
-      array_of_item_ids = withdraw_item.parse_uploaded_file
+    @withdraw_item = WithdrawItem.new(params[:withdraw_item])
+    if @withdraw_item.valid?
+      array_of_item_ids = @withdraw_item.parse_uploaded_file
       @uni_updates_batch = UniUpdatesBatch.create_withdraw_item_batch(params)
       UniUpdates.create_for_batch(array_of_item_ids, @uni_updates_batch)
       flash[:notice] = 'Batch uploaded!'


### PR DESCRIPTION
  Using instance variables triggers display of errors
  in associated views.
