### PR TITLE
Re-add logic to skip blank icat1s

### DIFF
--- a/app/views/shelf_selection_reports/load_saved_options.html.erb
+++ b/app/views/shelf_selection_reports/load_saved_options.html.erb
@@ -21,12 +21,14 @@
       <option value='<%= itype %>'><%= itype %></option>
     <% end %>
   </itypes>
-  <icat1sstring><%= @shelf_sel_search.icat1s %></icat1sstring>
-  <icat1s>
-    <% @shelf_sel_search.icat1s.split(',').each do |icat1| %>
-      <option value='<%= icat1 %>'><%= icat1 %></option>
-    <% end %>
-  </icat1s>
+  <% unless @shelf_sel_search.icat1s.blank? %>
+    <icat1sstring><%= @shelf_sel_search.icat1s %></icat1sstring>
+    <icat1s>
+      <% @shelf_sel_search.icat1s.split(',').each do |icat1| %>
+        <option value='<%= icat1 %>'><%= icat1 %></option>
+      <% end %>
+    </icat1s>
+  <% end %>
   <lang><%= @shelf_sel_search.lang %></lang>
   <minyr><%= @shelf_sel_search.min_yr %></minyr>
   <maxyr><%= @shelf_sel_search.max_yr %></maxyr>


### PR DESCRIPTION
  When a saved search is loaded that has no icat1s
  the select box is blank. I'd rather the select box
  re-populate with options, but I want to get searches 
  saving first.
