### PR TITLE
simplify js and handle nil icat1s

### DIFF
--- a/app/assets/javascripts/shelf_selection_reports.js
+++ b/app/assets/javascripts/shelf_selection_reports.js
@@ -61,18 +61,13 @@ $(document).ready(function() {
             })
           }
         })
-        $('#shelf_selection_report_fmt_array option').remove();
-        $('#shelf_selection_report_fmt_array').append($(html_opts).find('fmts option'));
         $.each($(html_opts).find('fmtsstring').text().split(','), function(i,e){
           $("#shelf_selection_report_fmt_array option[value='" + e + "']").prop('selected', true);
         });
-        $('#shelf_selection_report_itype_array option').remove();
-        $('#shelf_selection_report_itype_array').append($(html_opts).find('itypes option'));
         $.each($(html_opts).find('itypesstring').text().split(','), function(i,e){
           $("#shelf_selection_report_itype_array option[value='" + e + "']").prop('selected', true);
         });
-        $('#shelf_selection_report_icat1_array option').remove();
-        $('#shelf_selection_report_icat1_array').append($(html_opts).find('icat1s option'));
+        $('#shelf_selection_report_icat1_array option[value="ALL"]').prop('selected', false);
         $.each($(html_opts).find('icat1sstring').text().split(','), function(i,e){
           $("#shelf_selection_report_icat1_array option[value='" + e + "']").prop('selected', true);
         });

--- a/app/views/shelf_selection_reports/load_saved_options.html.erb
+++ b/app/views/shelf_selection_reports/load_saved_options.html.erb
@@ -21,12 +21,15 @@
       <option value='<%= itype %>'><%= itype %></option>
     <% end %>
   </itypes>
-  <icat1sstring><%= @shelf_sel_search.icat1s %></icat1sstring>
-  <icat1s>
-    <% @shelf_sel_search.icat1s.split(',').each do |icat1| %>
-      <option value='<%= icat1 %>'><%= icat1 %></option>
-    <% end %>
-  </icat1s>
+  <% if @shelf_sel_search.icat1s == nil %>
+  <% else %>
+    <icat1sstring><%= @shelf_sel_search.icat1s %></icat1sstring>
+    <icat1s>
+      <% @shelf_sel_search.icat1s.split(',').each do |icat1| %>
+        <option value='<%= icat1 %>'><%= icat1 %></option>
+      <% end %>
+    </icat1s>
+  <% end %>
   <lang><%= @shelf_sel_search.lang %></lang>
   <minyr><%= @shelf_sel_search.min_yr %></minyr>
   <maxyr><%= @shelf_sel_search.max_yr %></maxyr>


### PR DESCRIPTION
The javascript was too severe - it doesn't need to rebuild the whole option list from scratch, it now just selects the options specified by the string of options from the db.

Also, we need to be able to load saved searches where icat1s are nil.
