### PR TITLE
Fix call range

### DIFF
--- a/app/assets/stylesheets/modules/forms.scss
+++ b/app/assets/stylesheets/modules/forms.scss
@@ -21,7 +21,7 @@ a {
 
 .table-container {
   border: 1px solid;
-  height: 600px;
+  height: 400px;
   overflow: auto;
 }
 
@@ -30,4 +30,8 @@ hr {
   border-top: 1px solid $grayish-yellow;
   margin-bottom: 20px;
   margin-top: 20px;
+}
+
+div#error_explanation {
+  color: red;
 }

--- a/app/assets/stylesheets/modules/forms.scss
+++ b/app/assets/stylesheets/modules/forms.scss
@@ -32,6 +32,6 @@ hr {
   margin-top: 20px;
 }
 
-div#error_explanation {
-  color: red;
+#error-explanation {
+  color: $warning;
 }

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -1,5 +1,6 @@
 @import 'sul-variables';
 
+$warning: #f00;
 $brand-primary: $color-cardinal-red;
 $btn-primary-border: darken($brand-primary, 9.8%);
 

--- a/app/controllers/concerns/endow_funds_params.rb
+++ b/app/controllers/concerns/endow_funds_params.rb
@@ -1,11 +1,9 @@
 ##
 # Module to construct the Endow Funds Report params for endow_rpt.cgi
+# All the args in URL:
+# ('ckeys_filename')('date_range')('email')('funds')('output_format')
 ##
 module EndowFundsParams
-  extend ActiveSupport::Concern
-
-  # All the args in URL:
-  # ('ckeys_filename')('date_range')('email')('funds')('output_format')
   def submit_endow_funds(batch_params)
     report_params = {}
     ckeys_filename(report_params)

--- a/app/controllers/concerns/shelf_selection_params.rb
+++ b/app/controllers/concerns/shelf_selection_params.rb
@@ -26,10 +26,8 @@
 # url_mgt_rpts => URL for page of Mgt Rpt links (for whichever server requested this report)
 ##
 module ShelfSelectionParams
-  extend ActiveSupport::Concern
-
   def submit_shelf_selection(batch_params)
-    report_params = batch_params
+    report_params = batch_params.clone
     report_params.delete_if { |key| key.to_s.match(/call_\w+/) }
     report_params.delete_if { |key| key.to_s == 'search_name' }
     call_range(batch_params, report_params)
@@ -38,9 +36,13 @@ module ShelfSelectionParams
   end
 
   def call_range(batch_params, report_params)
-    report_params[:call_range] = "#{batch_params[:call_alpha]}-" if batch_params[:call_alpha].present?
-    if batch_params[:call_lo].present?
+    if batch_params[:call_alpha].present?
+      report_params[:call_range] = "#{batch_params[:call_alpha]}#{batch_params[:call_lo]}-#{batch_params[:call_hi]}"
+    elsif batch_params[:call_lo].present?
       report_params[:call_range] = "#{batch_params[:call_lo]}-#{batch_params[:call_hi]}"
+      report_params[:call_range] = "#{batch_params[:call_lo]}0-9999".gsub('#','') if batch_params[:call_lo].match(/\w+\#/)
+    elsif batch_params[:call_hi].present?
+      report_params[:call_range] = "OTHER-#{batch_params[:call_hi]}"
     end
   end
 

--- a/app/controllers/concerns/shelf_selection_params.rb
+++ b/app/controllers/concerns/shelf_selection_params.rb
@@ -40,7 +40,7 @@ module ShelfSelectionParams
       report_params[:call_range] = "#{batch_params[:call_alpha]}#{batch_params[:call_lo]}-#{batch_params[:call_hi]}"
     elsif batch_params[:call_lo].present?
       report_params[:call_range] = "#{batch_params[:call_lo]}-#{batch_params[:call_hi]}"
-      report_params[:call_range] = "#{batch_params[:call_lo]}0-9999".gsub('#','') if batch_params[:call_lo].match(/\w+\#/)
+      report_params[:call_range] = "#{batch_params[:call_lo]}0-9999".delete('#') if batch_params[:call_lo] =~ /\w+\#/
     elsif batch_params[:call_hi].present?
       report_params[:call_range] = "OTHER-#{batch_params[:call_hi]}"
     end

--- a/app/controllers/concerns/symphony_cgi.rb
+++ b/app/controllers/concerns/symphony_cgi.rb
@@ -3,10 +3,9 @@
 #  and connect to the Symphony cgi script to run the report
 ##
 module SymphonyCgi
-  extend ActiveSupport::Concern
   include EndowFundsParams
   include ShelfSelectionParams
-
+  
   def request_conn(script, cgi_params)
     @request_conn ||= begin
       request_url = request_url(script, cgi_params)

--- a/app/controllers/concerns/symphony_cgi.rb
+++ b/app/controllers/concerns/symphony_cgi.rb
@@ -5,7 +5,7 @@
 module SymphonyCgi
   include EndowFundsParams
   include ShelfSelectionParams
-  
+
   def request_conn(script, cgi_params)
     @request_conn ||= begin
       request_url = request_url(script, cgi_params)

--- a/app/models/circulation_statistics_report_format.rb
+++ b/app/models/circulation_statistics_report_format.rb
@@ -3,6 +3,6 @@ class CirculationStatisticsReportFormat < ActiveRecord::Base
   self.table_name = 'circ_stats_rpt_fmts'
 
   def self.formats
-    (select(:format).distinct.order(:format).pluck(:format)).sort.unshift('All Formats')
+    select(:format).distinct.order(:format).pluck(:format).sort.unshift('All Formats')
   end
 end

--- a/app/models/circulation_statistics_report_format.rb
+++ b/app/models/circulation_statistics_report_format.rb
@@ -3,6 +3,6 @@ class CirculationStatisticsReportFormat < ActiveRecord::Base
   self.table_name = 'circ_stats_rpt_fmts'
 
   def self.formats
-    (select(:format).distinct.order(:format).pluck(:format) + ['All Formats']).sort
+    (select(:format).distinct.order(:format).pluck(:format)).sort.unshift('All Formats')
   end
 end

--- a/app/models/shelf_sel_item_cat1.rb
+++ b/app/models/shelf_sel_item_cat1.rb
@@ -3,6 +3,6 @@ class ShelfSelItemCat1 < ActiveRecord::Base
   self.table_name = 'shelf_sel_item_cat1s'
 
   def self.item_category1s
-    (select(:item_category1).distinct.order(:item_category1).pluck(:item_category1)).sort.unshift('All Category1s')
+    select(:item_category1).distinct.order(:item_category1).pluck(:item_category1).sort.unshift('All Category1s')
   end
 end

--- a/app/models/shelf_sel_item_cat1.rb
+++ b/app/models/shelf_sel_item_cat1.rb
@@ -3,6 +3,6 @@ class ShelfSelItemCat1 < ActiveRecord::Base
   self.table_name = 'shelf_sel_item_cat1s'
 
   def self.item_category1s
-    (select(:item_category1).distinct.order(:item_category1).pluck(:item_category1) + ['ALL']).sort
+    (select(:item_category1).distinct.order(:item_category1).pluck(:item_category1)).sort.unshift('All Category1s')
   end
 end

--- a/app/models/shelf_selection_item_type.rb
+++ b/app/models/shelf_selection_item_type.rb
@@ -3,6 +3,6 @@ class ShelfSelectionItemType < ActiveRecord::Base
   self.table_name = 'shelf_sel_item_types'
 
   def self.item_types
-    (select(:item_type).distinct.order(:item_type).pluck(:item_type)).sort.unshift('All Item Types')
+    select(:item_type).distinct.order(:item_type).pluck(:item_type).sort.unshift('All Item Types')
   end
 end

--- a/app/models/shelf_selection_item_type.rb
+++ b/app/models/shelf_selection_item_type.rb
@@ -3,6 +3,6 @@ class ShelfSelectionItemType < ActiveRecord::Base
   self.table_name = 'shelf_sel_item_types'
 
   def self.item_types
-    (select(:item_type).distinct.order(:item_type).pluck(:item_type) + ['All Item Types']).sort
+    (select(:item_type).distinct.order(:item_type).pluck(:item_type)).sort.unshift('All Item Types')
   end
 end

--- a/app/models/shelf_selection_report.rb
+++ b/app/models/shelf_selection_report.rb
@@ -20,7 +20,7 @@ class ShelfSelectionReport
   validates :itype_array, length: { minimum: 2, message: "can't be empty" }, if: :classic_range_type?
   validates :fmt_array, length: { minimum: 2, message: "can't be empty" }, if: :other_range_type?
   validates :fmt_array, length: { minimum: 2, message: "can't be empty" }, if: :other_range_type?
-  validates :subj_name, length: { maximum: 80, message: "no more than 80 characters" }
+  validates :subj_name, length: { maximum: 80, message: 'no more than 80 characters' }
 
   def self.generic_options
     [["Doesn't matter", 0], ['INCLUDE only', 1], ['EXCLUDE', 2]]

--- a/app/models/shelf_selection_report.rb
+++ b/app/models/shelf_selection_report.rb
@@ -20,6 +20,7 @@ class ShelfSelectionReport
   validates :itype_array, length: { minimum: 2, message: "can't be empty" }, if: :classic_range_type?
   validates :fmt_array, length: { minimum: 2, message: "can't be empty" }, if: :other_range_type?
   validates :fmt_array, length: { minimum: 2, message: "can't be empty" }, if: :other_range_type?
+  validates :subj_name, length: { maximum: 80, message: "no more than 80 characters" }
 
   def self.generic_options
     [["Doesn't matter", 0], ['INCLUDE only', 1], ['EXCLUDE', 2]]

--- a/app/views/change_current_locations/new.html.erb
+++ b/app/views/change_current_locations/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Change Current Location Request Form</h2>
 <%= form_for @change_current_location, multipart: true, class: 'form-group' do |f| %>
   <% if @change_current_location.errors.any? %>
-    <div id="error_explanation">
+    <div id="error-explanation">
       <ul>
       <% @change_current_location.errors.full_messages.each do |msg| %>
         <li><%= msg %></li>

--- a/app/views/change_home_locations/new.html.erb
+++ b/app/views/change_home_locations/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Change Home Location Request Form</h2>
 <%= form_for @change_home_location, multipart: true, class: 'form-group' do |f| %>
   <% if @change_home_location.errors.any? %>
-    <div id="error_explanation">
+    <div id="error-explanation">
       <ul>
       <% @change_home_location.errors.full_messages.each do |msg| %>
         <li><%= msg %></li>

--- a/app/views/change_item_types/new.html.erb
+++ b/app/views/change_item_types/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Change Item Type Request Form</h2>
 <%= form_for @change_item_type, multipart: true, class: 'form-group' do |f| %>
   <% if @change_item_type.errors.any? %>
-    <div id="error_explanation">
+    <div id="error-explanation">
       <ul>
       <% @change_item_type.errors.full_messages.each do |msg| %>
         <li><%= msg %></li>

--- a/app/views/circulation_statistics_reports/new.html.erb
+++ b/app/views/circulation_statistics_reports/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Circulation Statistics Report Request</h2>
 <%= form_for @circulation_statistics_report, multipart: true, class: 'form-group' do |f| %>
   <% if @circulation_statistics_report.errors.any? %>
-    <div id="error_explanation">
+    <div id="error-explanation">
       <ul>
         <% @circulation_statistics_report.errors.full_messages.each do |msg| %>
           <li><%= msg %></li>

--- a/app/views/circulation_statistics_reports/new.html.erb
+++ b/app/views/circulation_statistics_reports/new.html.erb
@@ -202,6 +202,7 @@
 <div class="btn-group">
   <%= link_to 'Reset form', new_circulation_statistics_report_path, class: 'btn btn-md btn-primary btn-full' %>
   <%= link_to 'Proceed to next step', home_locations_for_libraries_path, class: 'btn btn-md btn-primary btn-full', id: 'populate-home-locations', remote: true %>
-  <%= main_menu_button %>
 </div>
+<div class="pad"><%= link_to 'Main menu', root_path, class: 'btn btn-md btn-primary btn-full' %></div>
+<HR>
 <%= render 'shared/call_number_range_examples' %>

--- a/app/views/encumbrance_reports/new.html.erb
+++ b/app/views/encumbrance_reports/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Encumbrance Report Request</h2>
 <%= form_for @encumbrance_report, multipart: true, class: 'form-group' do |f| %>
 <% if @encumbrance_report.errors.any? %>
-<div id="error_explanation">
+<div id="error-explanation">
   <ul>
     <% @encumbrance_report.errors.full_messages.each do |msg| %>
     <li><%= msg %></li>

--- a/app/views/endowed_funds_reports/new.html.erb
+++ b/app/views/endowed_funds_reports/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Endowed Funds Report Request</h2>
 <%= form_for @endowed_funds_report, multipart: true, class: 'form-group' do |f| %>
 <% if @endowed_funds_report.errors.any? %>
-<div id='error_explanation'>
+<div id='error-explanation'>
   <ul>
     <% @endowed_funds_report.errors.full_messages.each do |msg| %>
     <li><%= msg %></li>

--- a/app/views/endowed_funds_reports/new.html.erb
+++ b/app/views/endowed_funds_reports/new.html.erb
@@ -47,7 +47,6 @@
   <div class='pad'><%= f.submit 'Submit request', class: 'btn' %></div><br/>
 
   <% end %>
-  <div class='btn-group'>
-    <%= main_menu_button %>
-  </div>
+
+  <div><%= link_to 'Main menu', root_path, class: 'btn btn-md btn-primary btn-full' %></div>
 </div>

--- a/app/views/expenditure_reports/new.html.erb
+++ b/app/views/expenditure_reports/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Expenditure Report Request</h2>
 <%= form_for @expenditure_report, multipart: true, class: 'form-group' do |f| %>
 <% if @expenditure_report.errors.any? %>
-<div id='error_explanation'>
+<div id='error-explanation'>
   <ul>
     <% @expenditure_report.errors.full_messages.each do |msg| %>
     <li><%= msg %></li>

--- a/app/views/expenditures_with_circ_stats_reports/new.html.erb
+++ b/app/views/expenditures_with_circ_stats_reports/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Expenditures with Circ Stats Report Request</h2>
 <%= form_for @expenditures_with_circ_stats_report, class: 'form-group' do |f| %>
 <% if @expenditures_with_circ_stats_report.errors.any? %>
-<div id="error_explanation">
+<div id="error-explanation">
   <ul>
     <% @expenditures_with_circ_stats_report.errors.full_messages.each do |msg| %>
     <li><%= msg %></li>

--- a/app/views/sal3_batch_requests_batches/new.html.erb
+++ b/app/views/sal3_batch_requests_batches/new.html.erb
@@ -1,7 +1,7 @@
 <h2>SAL3 Batch Request</h2>
 <%= form_for @sal3_batch_requests_batch, multipart: true, class: 'form-group' do |f| %>
 <% if @sal3_batch_requests_batch.errors.any? %>
-<div id="error_explanation">
+<div id="error-explanation">
   <ul>
     <% @sal3_batch_requests_batch.errors.full_messages.each do |msg| %>
     <li><%= msg %></li>

--- a/app/views/shared/_circulation_statistics_report_formats.html.erb
+++ b/app/views/shared/_circulation_statistics_report_formats.html.erb
@@ -1,6 +1,6 @@
 <div class='form-group row'>
   <%= f.label :fmt_array, 'Select the formats to include:', class: 'col-sm-10 form-control-label' %>
   <div class='col-sm-10'>
-    <%= f.select :fmt_array, CirculationStatisticsReportFormat.formats, {}, { multiple: true, class: 'form-control' } %>
+    <%= f.select :fmt_array, CirculationStatisticsReportFormat.formats, { selected: 'All Formats' }, { multiple: true, class: 'form-control' } %>
   </div>
 </div>

--- a/app/views/shelf_selection_reports/new.html.erb
+++ b/app/views/shelf_selection_reports/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Shelf Selection Report Request</h2>
 <%= form_for @shelf_selection_report, class: 'form-group' do |f| %>
   <% if @shelf_selection_report.errors.any? %>
-    <div id="error_explanation">
+    <div id="error-explanation">
       <ul>
         <% @shelf_selection_report.errors.full_messages.each do |msg| %>
           <li><%= msg %></li>

--- a/app/views/shelf_selection_reports/new.html.erb
+++ b/app/views/shelf_selection_reports/new.html.erb
@@ -37,13 +37,13 @@
   <div class='form-group row'>
     <%= f.label :itype_array, 'Select the item types to include:', class: 'col-sm-10 form-control-label' %>
     <div class='col-sm-10'>
-      <%= f.select :itype_array, ShelfSelectionItemType.item_types, {}, { multiple: true, class: 'form-control' } %>
+      <%= f.select :itype_array, ShelfSelectionItemType.item_types, { selected: 'All Item Types' }, { multiple: true, class: 'form-control' } %>
     </div>
   </div>
   <div class='form-group row'>
     <%= f.label :icat1_array, 'Select the item category1s to include:', class: 'col-sm-10 form-control-label' %>
     <div class='col-sm-10'>
-      <%= f.select :icat1_array, ShelfSelItemCat1.item_category1s, { selected: 'All Item Category1s' }, { multiple: true, class: 'form-control' } %>
+      <%= f.select :icat1_array, ShelfSelItemCat1.item_category1s, { selected: 'All Category1s' }, { multiple: true, class: 'form-control' } %>
     </div>
   </div>
   <div class='form-group row'>Leave any text input fields below blank to not filter by those conditions</div>
@@ -131,15 +131,15 @@
   <div class='form-group row'><strong>Type of Call Number selection to use in the report:</strong> <em>(See bottom of page for examples of call number options)</em></div>
   <div class='form-group row'>
     <%= f.label :range_type, 'LC Letters Range: All LC call numbers beginning with specified letter(s) or range of letters', class:'col-sm-10 form-control-label' do %>
-        <%= f.radio_button :range_type, 'lc', checked: 'checked' %>
-        LC Letters Range: All LC call numbers beginning with specified letter(s) or range of letters
+        <%= f.radio_button :range_type, 'lc', { checked: 'checked', onChange: '$("input[id*=\'_call_\']").val("")' } %>
+        LC Letter Range: All LC call numbers beginning with specified letter(s) or range of letters
     <% end %>
     <%= f.label :range_type, 'Classic Selection: LC numerical range all beginning with same letter(s), or any range of Dewey numbers', class:'col-sm-10 form-control-label' do %>
-      <%= f.radio_button :range_type, 'classic' %>
+      <%= f.radio_button :range_type, 'classic', { onChange: '$("input[id*=\'_call_\']").val("")' } %>
       Classic Selection: LC numerical range all beginning with same letter(s), or any range of Dewey numbers
     <% end %>
     <%= f.label :range_type, 'Other call numbers: All that are neither LC nor Dewey, optionally filtered by start of call number', class:'col-sm-10 form-control-label' do %>
-      <%= f.radio_button :range_type, 'other' %>
+      <%= f.radio_button :range_type, 'other', { onChange: '$("input[id*=\'_call_\']").val("")' } %>
       Other call numbers: All that are neither LC nor Dewey, optionally filtered by start of call number
     <% end %>
   </div>
@@ -154,8 +154,9 @@
     </div>
 
     <div id='lc-call-lo-label'>
-      <%= f.label :call_lo, 'Enter a letter or range of letters to select all LC call numbers beginning with the letter(s). Lowest letter(s) of LC call number range. One or two letters required
-or one letter followed by # symbol.', class: 'form-control-label' %>
+      <%= f.label :call_lo, '<em>Enter a letter or letter range to select all LC call numbers within that range</em>.
+      <br />Lowest letter or letters of LC call number range. One or two letters required. <br /><sub>Use \'#\' symbol
+      to restrict range to only call numbers beginning with this letter or letters</sub>'.html_safe, class: 'form-control-label' %>
     </div>
     <div id='classic-call-lo-label' style='display:none;'>
       <%= f.label :call_lo, 'Lowest number of call number range. Maximum 4 digits for LC, 3 digits for Dewey.', class: 'form-control-label' %>
@@ -164,20 +165,22 @@ or one letter followed by # symbol.', class: 'form-control-label' %>
       <%= f.text_field :call_lo, class: 'input-mini' %>
     </div>
     <div id='lc-call-hi-label'>
-      <%= f.label :call_hi, 'Highest letter(s) of LC call number range. Same number of letters as in first field, or leave blank for only letter(s) in first field.', class: 'form-control-label' %>
+      <%= f.label :call_hi, 'Highest letter or letters of LC call number range, or leave blank for entire range of letters entered as Lowest.', class: 'form-control-label' %>
     </div>
     <div id='classic-call-hi-label' style='display:none;'>
       <%= f.label :call_hi, 'Highest number of call number range. All decimal extensions of entered number will be included in report. Digits only, no decimal.', class: 'form-control-label' %>
     </div>
     <div id='other-call-hi-label' style='display:none;'>
-      <%= f.label :call_hi, 'Enter start of call number for all non-LC/Dewey call numbers starting with that (not case sensitive). Leave blank to select all.', class: 'form-control-label' %>
+      <%= f.label :call_hi, 'Enter start of call number for all non-LC/Dewey call numbers starting with this value (not case sensitive).
+      <br /><sub>Leave blank to select all non-LC/Dewey call numbers.</sub>'.html_safe, class: 'form-control-label' %>
     </div>
     <div>
       <%= f.text_field :call_hi, class: 'input-mini' %>
     </div>
   </div>
+  <P>
   <div class='form-group row'>
-    <%= f.label :subj_name, 'Name of selection. Leave blank to not use.', class: 'col-sm-10 form-control-label' %>
+    <%= f.label :subj_name, 'Name of this report\'s selection criteria. Leave blank to not use.', class: 'col-sm-10 form-control-label' %>
     <div class='col-sm-10'>
       <%= f.text_field :subj_name, class: 'form-control' %>
       <em>The control allows entering up to 80 characters.</em>
@@ -200,4 +203,5 @@ or one letter followed by # symbol.', class: 'form-control-label' %>
 <div class="btn-group pad">
   <%= main_menu_button %>
 </div>
+<HR>
 <%= render 'shared/call_number_range_examples' %>

--- a/app/views/transfer_items/new.html.erb
+++ b/app/views/transfer_items/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Transfer Items Request Form</h2>
 <%= form_for @transfer_item, multipart: true, class: 'form-group' do |f| %>
   <% if @transfer_item.errors.any? %>
-    <div id="error_explanation">
+    <div id="error-explanation">
       <ul>
       <% @transfer_item.errors.full_messages.each do |msg| %>
         <li><%= msg %></li>

--- a/app/views/withdraw_items/new.html.erb
+++ b/app/views/withdraw_items/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Withdraw Items Request Form</h2>
 <%= form_for @withdraw_item, multipart: true, class: 'form-group' do |f| %>
   <% if @withdraw_item.errors.any? %>
-    <div id="error_explanation">
+    <div id="error-explanation">
       <ul>
       <% @withdraw_item.errors.full_messages.each do |msg| %>
         <li><%= msg %></li>

--- a/spec/models/shelf_sel_item_cat1_spec.rb
+++ b/spec/models/shelf_sel_item_cat1_spec.rb
@@ -7,6 +7,6 @@ RSpec.describe ShelfSelItemCat1, type: :model do
 
   it 'returns array of item category1s' do
     FactoryGirl.create(:shelf_sel_item_cat1)
-    expect(ShelfSelItemCat1.item_category1s).to eq(%w(ALL BUSCORPRPT))
+    expect(ShelfSelItemCat1.item_category1s).to eq(['All Category1s', 'BUSCORPRPT'])
   end
 end

--- a/spec/models/shelf_selection_item_type_spec.rb
+++ b/spec/models/shelf_selection_item_type_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ShelfSelectionItemType, type: :model do
 
     it 'returns a list of item types' do
       FactoryGirl.create(:shelf_selection_item_type)
-      expect(ShelfSelectionItemType.item_types).to eq(['ATLAS', 'All Item Types'])
+      expect(ShelfSelectionItemType.item_types).to eq(['All Item Types', 'ATLAS'])
     end
   end
 end


### PR DESCRIPTION
Fixes #228 
Fixes #226 

Also, cleans up text on shelf selection form and takes care of some issues that @matthewahmed  identified:

> That fixes everything except one param, "call_range". I think I saw you deliberately excluded it from the script call, thinking it wasn't used, but it is necessary. The script works now when I add that to the URL (along with some tweaks to find matching titles).
> 
> The web form needs to generate a single call_range string from the call number input fields' text, with format varying by type.
> 
> Classic Selection is simple, it's either like "PA123-2345" for LC or "123-234" for Dewey.
> 
> With one exception below, LC Range takes whatever is in the two input fields and joins them with a hyphen, e.g. "A-Z", or "A-" if the the second field is empty. The exception is for letter followed by '#", e.g. "H#"; then the call_range value is the letter followed by "0-9999" without the "#", e.g. "H0-9999", like a Classic Selection range.
> 
> If converting input like "H#" gets messy, it wouldn't take much coding to have the cgi script do it, though I think you'd need to escape the '#'.
> 
> For "Other" selection, call_range always starts with "OTHER-", with any text in the input field appended as is, maybe nothing to append.
