### PR TITLE
Make sure that load_date gets set for UniUpdates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem 'okcomputer'
 gem 'sidekiq'
 
 group :production do
-  gem 'activerecord-oracle_enhanced-adapter'
+  gem 'activerecord-oracle_enhanced-adapter', '~> 1.6.0'
   gem 'ruby-oci8'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,7 +273,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord-oracle_enhanced-adapter
+  activerecord-oracle_enhanced-adapter (~> 1.6.0)
   bootstrap-sass (~> 3.3.4)
   bootstrap_form
   byebug

--- a/app/models/change_current_location.rb
+++ b/app/models/change_current_location.rb
@@ -10,7 +10,7 @@ class ChangeCurrentLocation
   attr_accessor :item_ids
   attr_accessor :email
   attr_accessor :comments
-  attr_accessor :batch_date
+  attr_accessor :load_date
   attr_accessor :user_name
   attr_accessor :action
   attr_accessor :priority

--- a/app/models/change_home_location.rb
+++ b/app/models/change_home_location.rb
@@ -11,7 +11,7 @@ class ChangeHomeLocation
   attr_accessor :item_ids
   attr_accessor :email
   attr_accessor :comments
-  attr_accessor :batch_date
+  attr_accessor :load_date
   attr_accessor :user_name
   attr_accessor :action
   attr_accessor :priority

--- a/app/models/change_item_type.rb
+++ b/app/models/change_item_type.rb
@@ -9,7 +9,7 @@ class ChangeItemType
   attr_accessor :item_ids
   attr_accessor :email
   attr_accessor :comments
-  attr_accessor :batch_date
+  attr_accessor :load_date
   attr_accessor :user_name
   attr_accessor :action
   attr_accessor :priority

--- a/app/models/transfer_item.rb
+++ b/app/models/transfer_item.rb
@@ -5,7 +5,7 @@ class TransferItem
   include FileParser
   include ActiveModel::Model
   attr_accessor :current_library, :new_library, :new_homeloc, :new_curloc, :new_item_type,
-                :item_ids, :email, :comments, :batch_date, :user_name, :action,
+                :item_ids, :email, :comments, :load_date, :user_name, :action,
                 :priority, :export_yn, :check_bc_first
   validates :current_library, :new_library, :new_homeloc, :item_ids,
             presence: true

--- a/app/models/uni_updates.rb
+++ b/app/models/uni_updates.rb
@@ -12,6 +12,7 @@ class UniUpdates < ActiveRecord::Base
     array_of_item_ids.each do |item_id|
       hashes_for_updates << {
         batch_id: uni_updates_batch.batch_id,
+        load_date: uni_updates_batch.batch_date,
         export_yn: uni_updates_batch.export_yn,
         priority: uni_updates_batch.priority,
         action: uni_updates_batch.action,
@@ -33,7 +34,7 @@ class UniUpdates < ActiveRecord::Base
     uniques = []
     duplicates = []
     item_ids.each do |item_id|
-      if UniUpdates.where(item_id: item_id).empty?
+      if UniUpdates.where(item_id: item_id, load_date: Time.zone.today).empty?
         uniques << item_id
       else
         duplicates << item_id

--- a/app/models/uni_updates_batch.rb
+++ b/app/models/uni_updates_batch.rb
@@ -8,7 +8,7 @@ class UniUpdatesBatch < ActiveRecord::Base
 
   # rubocop:disable Metrics/AbcSize
   def self.create_item_type_batch(params, total_bcs)
-    create(batch_date: params[:change_item_type][:batch_date],
+    create(batch_date: params[:change_item_type][:load_date],
            user_name: params[:change_item_type][:user_name],
            user_email: params[:change_item_type][:email],
            orig_lib: params[:change_item_type][:current_library],
@@ -23,7 +23,7 @@ class UniUpdatesBatch < ActiveRecord::Base
   end
 
   def self.create_withdraw_item_batch(params, total_bcs)
-    create(batch_date: params[:withdraw_item][:batch_date],
+    create(batch_date: params[:withdraw_item][:load_date],
            user_name: params[:withdraw_item][:user_name],
            user_email: params[:withdraw_item][:email],
            orig_lib: params[:withdraw_item][:current_library],
@@ -38,7 +38,7 @@ class UniUpdatesBatch < ActiveRecord::Base
   end
 
   def self.create_transfer_item_batch(params, total_bcs)
-    create(batch_date: params[:transfer_item][:batch_date],
+    create(batch_date: params[:transfer_item][:load_date],
            user_name: params[:transfer_item][:user_name],
            user_email: params[:transfer_item][:email],
            orig_lib: params[:transfer_item][:current_library],
@@ -56,7 +56,7 @@ class UniUpdatesBatch < ActiveRecord::Base
   end
 
   def self.create_current_location_batch(params, total_bcs)
-    create(batch_date: params[:change_current_location][:batch_date],
+    create(batch_date: params[:change_current_location][:load_date],
            user_name: params[:change_current_location][:user_name],
            user_email: params[:change_current_location][:email],
            orig_lib: params[:change_current_location][:current_library],
@@ -71,7 +71,7 @@ class UniUpdatesBatch < ActiveRecord::Base
   end
 
   def self.create_home_location_batch(params, total_bcs)
-    create(batch_date: params[:change_home_location][:batch_date],
+    create(batch_date: params[:change_home_location][:load_date],
            user_name: params[:change_home_location][:user_name],
            user_email: params[:change_home_location][:user_name],
            orig_lib: params[:change_home_location][:current_library],

--- a/app/models/withdraw_item.rb
+++ b/app/models/withdraw_item.rb
@@ -4,7 +4,7 @@
 class WithdrawItem
   include FileParser
   include ActiveModel::Model
-  attr_accessor :current_library, :item_ids, :email, :comments, :batch_date,
+  attr_accessor :current_library, :item_ids, :email, :comments, :load_date,
                 :user_name, :action, :priority, :export_yn, :check_bc_first
   validates :current_library, :item_ids, presence: true
 end

--- a/app/views/change_current_locations/new.html.erb
+++ b/app/views/change_current_locations/new.html.erb
@@ -45,7 +45,7 @@
       <%= f.text_area 'comments', class: 'form-control' %>
     </div>
   </div>
-  <%= f.hidden_field :batch_date, value: Time.now.strftime("%d-%b-%y").upcase %>
+  <%= f.hidden_field :load_date, value: DateTime.now.midnight %>
   <%= f.hidden_field :user_name, value: current_user.user_id %>
   <%= f.hidden_field :action, value: 'UPDCURLOC' %>
   <%= f.hidden_field :priority, value: 3 %>

--- a/app/views/change_home_locations/new.html.erb
+++ b/app/views/change_home_locations/new.html.erb
@@ -51,7 +51,7 @@
       <%= f.text_area 'comments', class: 'form-control' %>
     </div>
   </div>
-  <%= f.hidden_field :batch_date, value: Time.now.strftime("%d-%b-%y").upcase %>
+  <%= f.hidden_field :load_date, value: DateTime.now.midnight %>
   <%= f.hidden_field :user_name, value: current_user.user_id %>
   <%= f.hidden_field :action, value: 'UPDHOMELOC' %>
   <%= f.hidden_field :priority, value: 3 %>

--- a/app/views/change_item_types/new.html.erb
+++ b/app/views/change_item_types/new.html.erb
@@ -39,7 +39,7 @@
       <%= f.text_area 'comments', class: 'form-control' %>
     </div>
   </div>
-  <%= f.hidden_field :batch_date, value: Time.now.strftime("%d-%b-%y").upcase %>
+  <%= f.hidden_field :load_date, value: DateTime.now.midnight %>
   <%= f.hidden_field :user_name, value: current_user.user_id %>
   <%= f.hidden_field :action, value: 'UPDITEMTYPE' %>
   <%= f.hidden_field :priority, value: 3 %>

--- a/app/views/sal3_batch_requests_batches/new.html.erb
+++ b/app/views/sal3_batch_requests_batches/new.html.erb
@@ -79,13 +79,13 @@
         <div class='form-group row'>
           <%= f.label :batch_startdate, "Delivery start date:", class: 'col-sm-2 form-control-label' %>
           <div class='col-sm-10'>
-            <%= f.date_field 'batch_startdate', id: 'dp1', class: 'form-control', value: "#{Time.now.strftime("%d-%b-%y")}" %>
+            <%= f.date_field 'batch_startdate', id: 'dp1', class: 'form-control', value: "#{DateTime.now.midnight}" %>
           </div>
         </div>
         <div class='form-group row'>
           <%= f.label :batch_needbydate, "All items delivered by:", class: 'col-sm-2 form-control-label' %>
           <div class='col-sm-10'>
-            <%= f.date_field 'batch_needbydate', id: 'dp2', class: 'form-control', value: "#{Time.now.strftime("%d-%b-%y")}" %>
+            <%= f.date_field 'batch_needbydate', id: 'dp2', class: 'form-control', value: "#{DateTime.now.midnight}" %>
           </div>
         </div>
         <div class='indent'>
@@ -146,8 +146,8 @@
   <%= f.hidden_field :num_nonsymph_bcs, value: '' %>
   <%= f.hidden_field :num_retrieval_err, value: '' %>
   <%= f.hidden_field :pending, value: 'Y' %>
-  <%= f.hidden_field :load_date, value: Time.now.strftime("%d-%b-%y").upcase %>
-  <%= f.hidden_field :last_action_date, value: Time.now.strftime("%d-%b-%y").upcase %>
+  <%= f.hidden_field :load_date, value: DateTime.now.midnight %>
+  <%= f.hidden_field :last_action_date, value: DateTime.now.midnight %>
   <div><%= f.submit 'Submit request', class: 'btn' %></div><br/>
 </div>
 <% end %>

--- a/app/views/transfer_items/new.html.erb
+++ b/app/views/transfer_items/new.html.erb
@@ -57,7 +57,7 @@
       <%= f.text_area 'comments', class: 'form-control' %>
     </div>
   </div>
-  <%= f.hidden_field :batch_date, value: Time.now.strftime("%d-%b-%y").upcase %>
+  <%= f.hidden_field :load_date, value: DateTime.now.midnight %>
   <%= f.hidden_field :user_name, value: current_user.user_id %>
   <%= f.hidden_field :action, value: 'TRANSFER' %>
   <%= f.hidden_field :priority, value: 3 %>

--- a/app/views/withdraw_items/new.html.erb
+++ b/app/views/withdraw_items/new.html.erb
@@ -33,7 +33,7 @@
       <%= f.text_area 'comments', class: 'form-control' %>
     </div>
   </div>
-  <%= f.hidden_field :batch_date, value: Time.now.strftime("%d-%b-%y").upcase %>
+  <%= f.hidden_field :load_date, value: DateTime.now.midnight %>
   <%= f.hidden_field :user_name, value: current_user.user_id %>
   <%= f.hidden_field :action, value: 'WITHDRAW' %>
   <%= f.hidden_field :priority, value: 3 %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -12,6 +12,7 @@ default: &default
 development:
   <<: *default
   database: db/development.sqlite3
+  nls_date_format: DD-MON-RR
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -23,3 +24,4 @@ test:
 production:
   <<: *default
   database: db/production.sqlite3
+  nls_date_format: DD-MON-RR

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -25,6 +25,9 @@ Rails.application.configure do
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = false
 
+  # Set up a development logger
+  # config.logger = Logger.new(STDOUT)
+  # config.log_level = :info
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true

--- a/config/initializers/oracle.rb
+++ b/config/initializers/oracle.rb
@@ -1,0 +1,23 @@
+# Set time zone in TZ environment variable so that the same timezone will be used by Ruby and by Oracle session
+ENV['TZ'] = 'PST'
+
+if Rails.env.development? || Rails.env.production? 
+  ActiveSupport.on_load(:active_record) do
+    ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.class_eval do
+      # id columns and columns which end with _id will always be converted to integers
+      self.emulate_integers_by_column_name = true
+
+      # DATE columns which include "date" in name will be converted to Date, otherwise to Time
+      self.emulate_dates_by_column_name = true
+
+      # true and false will be stored as 'Y' and 'N'
+      # self.emulate_booleans_from_strings = true
+
+      # start primary key sequences from 1 (and not 10000) and take just one next value in each session
+      # self.default_sequence_start_value = "1 NOCACHE INCREMENT BY 1"
+
+      # Use old visitor for Oracle 12c database
+      # self.use_old_oracle_visitor = true
+    end
+  end
+end

--- a/db/migrate/20161215190807_change_uni_updates_load_date.rb
+++ b/db/migrate/20161215190807_change_uni_updates_load_date.rb
@@ -1,0 +1,5 @@
+class ChangeUniUpdatesLoadDate < ActiveRecord::Migration
+  def change
+    change_column :uni_updates, :load_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161114234536) do
+ActiveRecord::Schema.define(version: 20161215190807) do
 
   create_table "authorized_user", force: :cascade do |t|
     t.string   "user_id"
@@ -303,7 +303,7 @@ ActiveRecord::Schema.define(version: 20161114234536) do
     t.integer  "batch_id"
     t.string   "pending"
     t.string   "export_yn"
-    t.datetime "load_date"
+    t.date     "load_date"
     t.integer  "priority"
     t.string   "action"
     t.string   "item_id"

--- a/spec/init_libsys_webforms.rb
+++ b/spec/init_libsys_webforms.rb
@@ -1,5 +1,13 @@
 require 'csv'
 
+UnicornPolicy.destroy_all
+keys = %w(type policy_num name description shadowed destination)
+csv_text = File.read('/Users/jgreben/Projects/libsys-webforms/spec/fixtures/files/unicorn_policies.csv')
+csv = CSV.parse(csv_text, headers: false)
+csv.map { |a| Hash[keys.zip(a)] }
+hash = csv.map { |a| Hash[keys.zip(a)] }
+UnicornPolicy.create(hash)
+
 ExpendituresFunds.destroy_all
 keys = %w(fund_id fund_name_key old_fund_id min_pay_date max_pay_date is_endow inv_lib)
 csv_text = File.read('/Users/jgreben/Projects/libsys-webforms/spec/fixtures/files/expenditures_funds.csv')


### PR DESCRIPTION
Also filter_duplicates method uses load_date for select, and load_date gets set properly and is of type `:date`. Configure the oracle_enhanced_adapter correctly pinned to the correct version, with an initializer file and the nls_date_format set in the database.yml file. This will close #249. 