### PR TITLE
Ckey2bibframe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@
 /tmp
 
 /coverage
+/loc_marc2bibframe2
+/lib/xform-marc21-to-xml-jar-with-dependencies.jar
 
 config/settings.local.yml
 config/settings/*.local.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,7 @@ AllCops:
 #    - 'spec/teaspoon_env.rb'
     - 'vendor/**/*'
     - 'lib/tasks/display-coverage.rake'
+    - 'loc_marc2bibframe2/**/*'
 
 Metrics/LineLength:
   Max: 120
@@ -33,4 +34,7 @@ Style/FrozenStringLiteralComment:
   Enabled: false
 
 Lint/HandleExceptions:
+  Enabled: false
+
+Rails/HttpPositionalArguments:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,10 @@ gem 'faraday'
 gem 'config'
 # Use okcomputer to set up checks to monitor
 gem 'okcomputer'
+# Use nokogiri for xml printing
+gem 'nokogiri'
+# Use systemu to handle OS calls
+gem 'systemu'
 
 group :production do
   gem 'activerecord-oracle_enhanced-adapter', '~> 1.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
     multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (3.2.0)
+    net-ssh (4.1.0)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
@@ -237,6 +237,7 @@ GEM
       net-ssh (>= 2.8.0)
     sul_styles (0.6.0)
       rails (~> 4.1)
+    systemu (2.6.5)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
     therubyracer (0.12.2)
@@ -279,6 +280,7 @@ DEPENDENCIES
   faraday
   jbuilder (~> 2.0)
   jquery-rails (< 4.1)
+  nokogiri
   okcomputer
   rails (~> 4.2.7.1)
   rspec-rails (~> 3.0)
@@ -289,6 +291,7 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   sqlite3
   sul_styles
+  systemu
   therubyracer
   web-console (~> 2.0)
 

--- a/README.md
+++ b/README.md
@@ -76,3 +76,7 @@ For example, to upload and delete batches:
 
     $ bundle exec rake webforms:change_current_location[:path_to_file,:current_lib,:new_curloc,:email, :comments]
     $ bundle exec rake webforms:delete_batch[batch_id]    
+
+## Ckey2Bibframe Webform
+
+The "Ckey2Bibframe" webform allows you to enter a Symphony ckey and view <strong>marc21-to-xml</strong> and <strong>marcxml-to-bibframe2</strong> results in the browser. In order for this functionality to work you must install the <a href="https://github.com/lcnetdev/marc2bibframe2">LOC Marc2Bibframe2 Converter</a> and place it under this application's root. Running the LOC marc2bibframe2 converter via libsys-webforms requires the `xsltproc` command-line tool be installed on your system (see http://www.xmlsoft.org). After cloning this project, simply `cd libsys-webforms` and then `git clone https://github.com/lcnetdev/marc2bibframe2.git`. If it is not already there, you must also create a `lib/xform-marc21-to-xml-jar-with-dependencies.jar` file that is compiled from https://github.com/sul-dlss/ld4p-marc21-to-xml (see https://github.com/sul-dlss/ld4p-marc21-to-xml#compiling-and-executing, it should be placed in this app's lib folder as well).

--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,4 @@ require File.expand_path('../config/application', __FILE__)
 Rails.application.load_tasks
 
 task default: [:rubocop, :scss_lint, :spec, :display_coveralls_coverage]
+task no_cop: [:scss_lint, :spec, :display_coveralls_coverage]

--- a/app/controllers/ckey2bibframes_controller.rb
+++ b/app/controllers/ckey2bibframes_controller.rb
@@ -1,0 +1,29 @@
+# Controller for the Ckey2bibframe form
+class Ckey2bibframesController < ApplicationController
+  def new
+    @ckey2bibframe = Ckey2bibframe.new
+  end
+
+  def create
+    @ckey2bibframe = Ckey2bibframe.new(ckey2bibframe_params)
+
+    if @ckey2bibframe.valid?
+      render action: 'show'
+    else
+      flash[:warning] = 'Check that all form fields are entered!'
+      render action: 'new'
+    end
+  end
+
+  def show
+    params[:baseuri] ||= Settings.base_uri
+    @ckey2bibframe = Ckey2bibframe.new(baseuri: params[:baseuri], ckey: params[:ckey])
+  end
+
+  private
+
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def ckey2bibframe_params
+    params.require(:ckey2bibframe).permit(:ckey, :baseuri)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,4 +15,11 @@ module ApplicationHelper
       class: 'btn btn-md btn-primary btn-full'
     ), root_path
   end
+
+  def conversion_button
+    link_to button_tag(
+      'Do another conversion',
+      class: 'btn btn-md btn-default btn-full'
+    ), new_ckey2bibframe_path
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -5,11 +5,16 @@ class Ability
   def initialize(current_user)
     current_user ||= AuthorizedUser.new
     assign_staff_permission(current_user)
-    assign_basic_permission if current_user
+    assign_basic_permission
+    assign_user_permission if current_user
     assign_batch_permission if current_user.unicorn_updates == 'Y'
   end
 
   def assign_basic_permission
+    can :manage, Ckey2bibframe
+  end
+
+  def assign_user_permission
     can :manage, BatchRecordUpdate
   end
 

--- a/app/models/ckey2bibframe.rb
+++ b/app/models/ckey2bibframe.rb
@@ -1,0 +1,44 @@
+# SSH to Symphony and run a catalogdump on a ckey
+class Ckey2bibframe
+  include OperatingSystem
+  include ActiveModel::Model
+  include ActiveModel::Validations
+  attr_accessor :ckey, :baseuri, :marcxml
+  validates :ckey, numericality: { message: ': You must enter a known ckey!' }
+
+  def convert
+    symphony_ssh = "ssh #{Settings.symphony_user}@#{Settings.symphony_host}"
+    symphony_env = "source #{Settings.symphony_env}"
+    catalogdump = "echo #{ckey} | #{Settings.symphony_catalogdump}"
+
+    jar = 'lib/xform-marc21-to-xml-jar-with-dependencies.jar'
+    java_command = "java -Djava.security.egd=file:/dev/../dev/urandom -cp #{jar} edu.stanford.MarcToXMLStream"
+
+    "#{symphony_ssh} '#{symphony_env} && #{catalogdump}' | #{java_command}"
+  end
+
+  def marc21_to_xml
+    begin
+      marcxml = execute_command(convert).force_encoding('UTF-8')
+    rescue => e
+      Rails.logger.warn('Unable to connect to Symphony via SSH.')
+      Rails.logger.error(e)
+    end
+    marcxml_file.write(marcxml)
+    Nokogiri::XML(marcxml, &:noblanks)
+  end
+
+  def marcxml_to_bibframe
+    marcxml_file.read
+    bf2_xsl = 'loc_marc2bibframe2/xsl/marc2bibframe2.xsl'
+    command = "xsltproc --stringparam baseuri #{baseuri} #{bf2_xsl} #{@marcxml_file.path}"
+    bibframe = execute_command(command).force_encoding('UTF-8')
+    marcxml_file.close
+    marcxml_file.delete
+    Nokogiri::XML(bibframe, &:noblanks)
+  end
+
+  def marcxml_file
+    @marcxml_file ||= Tempfile.new("#{ckey}.xml")
+  end
+end

--- a/app/views/ckey2bibframes/new.html.erb
+++ b/app/views/ckey2bibframes/new.html.erb
@@ -1,0 +1,36 @@
+<h1>Ckey to Bibframe2 Conversion</h1>
+
+<%= form_for(@ckey2bibframe) do |f| %>
+<% if @ckey2bibframe.errors.any? %>
+<div id="error_explanation">
+  <ul>
+    <% @ckey2bibframe.errors.full_messages.each do |message| %>
+    <li><%= message %></li>
+    <% end %>
+  </ul>
+</div>
+<% end %>
+
+<div class='form-group row'>
+  <%= f.label :ckey, 'Ckey for conversion:', class: 'col-sm-5 form-control-label' %>
+  <div class='col-sm-10'>
+    <%= f.text_field 'ckey', class: 'form-control' %>
+  </div>
+</div>
+
+<div class='form-group row'>
+  <%= f.label :baseuri, 'Base URI for local namespace:', class: 'col-sm-5 form-control-label' %>
+  <div class='col-sm-10'>
+    <%= f.text_field 'baseuri', value: "#{Settings.base_uri}", class: 'form-control' %>
+  </div>
+</div>
+
+<div class="btn-group">
+  <%= f.submit 'Do conversion', class: 'btn btn-md btn-default btn-full' %>
+</div>
+
+<% end %>
+<p>
+<div class="btn-group">
+  <%= main_menu_button %>
+</div>

--- a/app/views/ckey2bibframes/show.html.erb
+++ b/app/views/ckey2bibframes/show.html.erb
@@ -1,0 +1,19 @@
+<h1>Ckey to Bibframe2 Conversion</h1>
+<div class="btn-group">
+  <%= conversion_button %>
+</div>
+<h3>MarcXML for ckey <%= @ckey2bibframe.ckey %></h3>
+<pre>
+  <%= @ckey2bibframe.marc21_to_xml %>
+</pre>
+<h3>Bibframe2 for ckey <%= @ckey2bibframe.ckey %></h3>
+<pre>
+  <%= @ckey2bibframe.marcxml_to_bibframe %>
+</pre>
+<div class="btn-group">
+  <%= conversion_button %>
+</div>
+<p></p>
+<div class="btn-group">
+  <%= main_menu_button %>
+</div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,64 +1,68 @@
 <div class="home-page-section">
   <h1>SUL Staff Web Forms</h1>
-  <% if current_user %>
-  <h3>What would you like to do?</h3>
-
-  <% if can? :manage, BatchRecordUpdate %>
-  <div class="panel panel-default">
-    <div class="panel-heading" role="tab" id="headingOne">
-      <h4><%= link_to "Batch record updates", 'batch_record_updates' %></h4>
-    </div>
+  <% if !current_user %>
+  <div class="access-error">
+    You do not have permissions to use other staff web forms.
   </div>
-  <% end %>
-
-  <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
-    <% if can? :create, Sal3BatchRequestsBatch %>
+  <%= link_to "Login here", login_path(referrer: request.original_url) %>
+  <% else %>
+    <h3>What would you like to do?</h3>
+    <% if can? :manage, BatchRecordUpdate %>
     <div class="panel panel-default">
       <div class="panel-heading" role="tab" id="headingOne">
-        <h4 class="panel-title">
-          <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
-            SAL3 Batch Requests
-          </a>
-        </h4>
-      </div>
-      <div id="collapseOne" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingOne">
-        <ul>
-          <li><%= link_to "Place batch request", new_sal3_batch_requests_batch_path %></li>
-          <% if can? :read, Sal3BatchRequestsBatch and can? :update, Sal3BatchRequestsBatch %>
-            <li><%= link_to "Review batches", sal3_batch_requests_batches_path %></li>
-          <% end %>
-        </ul>
+        <h4><%= link_to "Batch record updates", 'batch_record_updates' %></h4>
       </div>
     </div>
     <% end %>
-    <% if can? :manage, ManagementReport %>
+    <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+      <% if can? :create, Sal3BatchRequestsBatch %>
+      <div class="panel panel-default">
+        <div class="panel-heading" role="tab" id="headingOne">
+          <h4 class="panel-title">
+            <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
+              SAL3 Batch Requests
+            </a>
+          </h4>
+        </div>
+        <div id="collapseOne" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingOne">
+          <ul>
+            <li><%= link_to "Place batch request", new_sal3_batch_requests_batch_path %></li>
+            <% if can? :read, Sal3BatchRequestsBatch and can? :update, Sal3BatchRequestsBatch %>
+              <li><%= link_to "Review batches", sal3_batch_requests_batches_path %></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+      <% end %>
+      <% if can? :manage, ManagementReport %>
+      <div class="panel panel-default">
+        <div class="panel-heading" role="tab" id="headingTwo">
+          <h4 class="panel-title">
+            <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseTwo" aria-expanded="true" aria-controls="collapseTwo">
+              Management Reports
+            </a>
+          </h4>
+        </div>
+        <div id="collapseTwo" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingTwo">
+          <%= render template: "management_reports/index" %>
+        </div>
+      </div>
+      <% end %>
+    </div>
+    <% if can? :create, UserloadRerun %>
     <div class="panel panel-default">
-      <div class="panel-heading" role="tab" id="headingTwo">
-        <h4 class="panel-title">
-          <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseTwo" aria-expanded="true" aria-controls="collapseTwo">
-            Management Reports
-          </a>
-        </h4>
-      </div>
-      <div id="collapseTwo" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingTwo">
-        <%= render template: "management_reports/index" %>
+      <div class="panel-heading" role="tab" id="headingOne">
+        <h4><%= link_to "Userload Rerun", new_userload_rerun_path %></h4>
       </div>
     </div>
     <% end %>
-  </div>
-
-  <% if can? :create, UserloadRerun %>
+  <% end %>
+  <% if can? :manage, Ckey2bibframe %>
+  <p></p>
   <div class="panel panel-default">
     <div class="panel-heading" role="tab" id="headingOne">
-      <h4><%= link_to "Userload Rerun", new_userload_rerun_path %></h4>
+      <h4><%= link_to "Ckey to Bibframe Conversion", new_ckey2bibframe_path %></h4>
     </div>
   </div>
-  <% end %>
-  <% else %>
-  <div class="access-error">
-    You do not have permissions to use any web forms.
-  </div>
-  <hr>
-  <%= link_to "Login here", login_path(referrer: request.original_url) %>
   <% end %>
 </div>

--- a/app/views/userload_reruns/new.html.erb
+++ b/app/views/userload_reruns/new.html.erb
@@ -15,13 +15,13 @@
     <%= f.label :rerun_date %><br>
     <%= f.date_field(:rerun_date, value: params[:rerun_date] || Time.zone.today, 'data-behavior': 'rerun-date-picker', min: 1.week.ago, max: Time.zone.today) %>
   </div>
-
+  <p>
   <div class="btn-group">
     <%= f.submit 'Rerun userload for this date', class: 'btn btn-md btn-default btn-full' %>
   </div>
 
 <% end %>
-
+<p>
 <div class="btn-group">
   <%= main_menu_button %>
 </div>

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,12 +25,36 @@ set :log_level, :info
 # Default value for :linked_files is []
 set :linked_files, %w(config/secrets.yml config/database.yml)
 # Default value for linked_dirs is []
-set :linked_dirs, %w(log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system public/uploads config/settings)
+set :linked_dirs, %w(log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system public/uploads config/settings loc_marc2bibframe2)
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }
 
 # Default value for keep_releases is 5
 # set :keep_releases, 5
+
+namespace :loc do
+
+  desc 'git clone LOC marc2bibframe2 (if it does not exist already)'
+  task :clone_marc2bibframe2 do
+    on roles(:web) do
+      cmd  = "cd #{shared_path} && "
+      cmd += "if [ ! -d loc_marc2bibframe2 ]; then "
+      cmd += "  git clone https://github.com/lcnetdev/marc2bibframe2.git loc_marc2bibframe2; "
+      cmd += "fi"
+      execute cmd
+    end
+  end
+
+  desc 'git pull master for LOC marc2bibframe2'
+  task update_marc2bibframe2: :clone_marc2bibframe2 do
+    on roles(:web) do
+      execute "cd #{shared_path}/loc_marc2bibframe2 && git pull origin master"
+    end
+  end
+
+end
+
+before 'deploy:updated', 'loc:update_marc2bibframe2'
 
 namespace :deploy do
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
   resources :expenditures_with_circ_stats_reports, only: [:new, :create]
   resources :endowed_funds_reports, only: [:new, :create]
   resources :userload_reruns, only: [:new, :create]
+  resources :ckey2bibframes, only: [:new, :create, :show], param: :ckey
+
 
   get 'shelf_selection_reports/home_locations' => 'shelf_selection_reports#home_locations', as: :home_locations_for_library
   get 'shelf_selection_reports/load_saved_options' => 'shelf_selection_reports#load_saved_options', as: :load_saved_options

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,1 +1,9 @@
+symphony_user: 'sirsi'
+symphony_env: '/s/SUL/Config/sirsi.env'
+symphony_host: 'morison.stanford.edu'
 symphony_cgi_url: 'http://morison.stanford.edu/cgi-bin/webforms'
+symphony_catalogdump: '/s/sirsi/Unicorn/Bin/catalogdump -om -kc -h -z -j -n dumpjunktag.Bibframe 2>/dev/null'
+# Note: the dumpjunktag.Bibframe file is located on the Symphony server under /s/sirsi/Unicorn/Custom/.
+#       It contains the tag listing '001' which instructs the catalogdump to remove all '001' fields of
+#       the MARC record. The -kc flag then adds back in an '001' field with the ckey as the value
+base_uri: 'http://ld4p-dev.stanford.edu/'

--- a/lib/operating_system.rb
+++ b/lib/operating_system.rb
@@ -1,0 +1,20 @@
+# Module to handle the OS commands needed for CKey2bibframe conversion
+module OperatingSystem
+  # Executes a system command in a subprocess.
+  # The method will return stdout from the command if execution was successful.
+  # The method will raise an exception if if execution fails.
+  # The exception's message will contain the explaination of the failure.
+  # @param [String] command the command to be executed
+  # @return [String] stdout from the command if execution was successful
+
+  def execute_command(command)
+    status, stdout, stderr = systemu(command)
+    raise stderr if status.exitstatus.nonzero?
+    return stdout
+  rescue
+    msg = "Command failed to execute: [#{command}] caused by
+          <STDERR = #{stderr}>"
+    msg << " STDOUT = #{stdout}" if stdout && !stdout.empty?
+    raise msg
+  end
+end

--- a/spec/controllers/ckey2bibframes_controller_spec.rb
+++ b/spec/controllers/ckey2bibframes_controller_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Ckey2bibframesController, type: :controller do
+  describe 'GET #new' do
+    it 'returns http success' do
+      get :new
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe 'GET #show' do
+    it 'returns http success' do
+      get :show, ckey: '123', baseuri: 'http://ld4p.stanford.edu'
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/features/ckey2bibframe_spec.rb
+++ b/spec/features/ckey2bibframe_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe 'Do a conversion' do
+  xit 'Does a conversion and displays a page with a conversion result' do
+    visit new_ckey2bibframe_path
+
+    fill_in 'ckey2bibframe_ckey', with: '123'
+    fill_in 'ckey2bibframe_baseuri', with: Settings.base_uri.to_s
+
+    click_button 'Do conversion'
+
+    expect(page).to have_css('h1', text: 'Ckey to Bibframe2 Conversion')
+    expect(page).to have_css('h3', text: 'MarcXML')
+    expect(page).to have_css('h3', text: 'Bibframe2')
+    expect(page).to have_css('pre', text: '<?xml version="1.0" encoding="UTF-8"?>')
+    expect(page).to have_css('pre', text: '<marcxml:controlfield tag="001">123</marcxml:controlfield>')
+    expect(page).to have_css('pre', text: %(<bf:Work rdf:about="#{Settings.base_uri}123#Work">))
+  end
+end

--- a/spec/models/ckey2bibframe_spec.rb
+++ b/spec/models/ckey2bibframe_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+require 'net/ssh'
+
+RSpec.describe Ckey2bibframe, type: :model do
+  describe 'SSH to server and retrieve some data' do
+    before(:each) do
+      session = double(Net::SSH::Connection::Session)
+      allow(session).to receive(:exec).and_return('marc')
+      allow(session).to receive(:close)
+
+      ssh = double(Net::SSH)
+      allow(ssh).to receive(:start).and_return(session)
+    end
+
+    it 'should check for a ckey' do
+      f = Ckey2bibframe.new(ckey: 'wmd', baseuri: 'http://example.com').valid?
+      expect(f).to be_falsey
+      t = Ckey2bibframe.new(ckey: '123', baseuri: 'http://example.com').valid?
+      expect(t).to be_truthy
+    end
+
+    it 'should do a convert' do
+      c = Ckey2bibframe.new(ckey: '123', baseuri: 'http://example.com')
+      expect(c.convert).to include('ssh',
+                                   'echo 123',
+                                   'xform-marc21-to-xml-jar-with-dependencies.jar',
+                                   'edu.stanford.MarcToXMLStream')
+    end
+
+    it 'should convert marc21 to xml' do
+      c = double(Ckey2bibframe.new(ckey: '123', baseuri: 'http://example.com'))
+      allow(c).to receive(:marc21_to_xml).and_return('some_marcxml')
+      expect(c.marc21_to_xml).to eq('some_marcxml')
+    end
+
+    it 'should convert marcxml to bibframe' do
+      c = double(Ckey2bibframe.new(ckey: '123', baseuri: 'http://example.com'))
+      allow(c).to receive(:marcxml_to_bibframe).and_return('some_bibframe')
+      expect(c.marcxml_to_bibframe).to eq('some_bibframe')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ Coveralls.wear!('rails')
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  require File.expand_path("../../config/environment", __FILE__)
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
This addition creates a model, controller and set of views for the creation and subsequent display of a ckey2bibframe request. The request initiates an ssh to `libdbdev1` sources the `sirsi` environment and performs a `catalogdump` Symphony API command using the settings.yml to define the urls and command params. It pipes the `catalogdump` result to the `xform-marc21-to-xml-jar-with-dependencies.jar` java file and displays the result in the view and also outputs the result to a temporary file. That file is read by a method that initiates the `marc2bibframe2` converter (which is set up as a deploy hook) and that result is also displayed in the view.

Work is currently being done to create a deployment hook to fetch the `xform-marc21-to-xml-jar-with-dependencies.jar` as a deployment artifact from Travis (https://github.com/sul-dlss/ld4p-marc21-to-xml/issues/29).

An enhancement to this work could be to add in some exception handling of the system call to the java jar, or employ a gem such as JRuby to execute the java.