### PR TITLE
Support for Pl/SQL jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem 'honeybadger'
 group :production do
   gem 'activerecord-oracle_enhanced-adapter', '~> 1.6.0'
   gem 'ruby-oci8'
+  gem 'ruby-plsql'
 end
 
 gem 'therubyracer'
@@ -80,4 +81,5 @@ end
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'
+  gem 'ruby-plsql'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,6 +201,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-oci8 (2.2.2)
+    ruby-plsql (0.6.0)
     ruby-progressbar (1.8.1)
     sass (3.4.22)
     sass-rails (5.0.6)
@@ -283,6 +284,7 @@ DEPENDENCIES
   rspec-rails (~> 3.0)
   rubocop
   ruby-oci8
+  ruby-plsql
   sass-rails (~> 5.0)
   scss_lint
   sdoc (~> 0.4.0)

--- a/README.md
+++ b/README.md
@@ -84,3 +84,17 @@ For example, to upload and delete batches:
 ## Ckey2Bibframe Webform
 
 The "Ckey2Bibframe" webform allows you to enter a Symphony ckey and view <strong>marc21-to-xml</strong> and <strong>marcxml-to-bibframe2</strong> results in the browser. In order for this functionality to work you must install the <a href="https://github.com/lcnetdev/marc2bibframe2">LOC Marc2Bibframe2 Converter</a> and place it under this application's root. Running the LOC marc2bibframe2 converter via libsys-webforms requires the `xsltproc` command-line tool be installed on your system (see http://www.xmlsoft.org). After cloning this project, simply `cd libsys-webforms` and then `git clone https://github.com/lcnetdev/marc2bibframe2.git`. If it is not already there, you must also create a `lib/xform-marc21-to-xml-jar-with-dependencies.jar` file that is compiled from https://github.com/sul-dlss/ld4p-marc21-to-xml (see https://github.com/sul-dlss/ld4p-marc21-to-xml#compiling-and-executing, it should be placed in this app's lib folder as well).
+
+## PL/SQL Jobs
+
+Based on the configuration of a `pl_sql_job` in the settings/{environment}.yml file, e.g.:
+```
+pl_sql_jobs:
+  circ_stats_job:
+    text: 'Circ stats report daily processing'
+    command: 'circ_stats_rpt.daily_processing'
+    sunet_ids:
+      - 'usera'
+      - 'userb'
+```
+links with collapsed "Run" buttons will automatically be created on the home page and will only appear for people who are logged in and listed in the sunet_ids section of the config. Clicking the "Run" link will execute the configured PL/SQL command via the already configured OCI8 connection gem (using the environment's database.yml connection details). If more jobs need to be added in the future, just fill out a new section under the pl_sql_jobs section in the https://github.com/sul-dlss/shared_configs repository and follow the instructions there for deploying to the application server.

--- a/app/assets/stylesheets/modules/home-page.scss
+++ b/app/assets/stylesheets/modules/home-page.scss
@@ -23,3 +23,8 @@ h1 {
   color: $color-cardinal-red;
   font-size: 1.25em;
 }
+
+.link {
+  color: $color-cardinal-red;
+  cursor: pointer;
+}

--- a/app/controllers/pl_sql_job_controller.rb
+++ b/app/controllers/pl_sql_job_controller.rb
@@ -1,0 +1,19 @@
+# Controller class to execute PL/SQL jobs
+class PlSqlJobController < ApplicationController
+  def create
+    begin
+      plsql.instance_eval(create_params[:command])
+    rescue => error
+      flash[:error] = "Error - cannot run #{create_params[:command]}: #{error}"
+    else
+      flash[:success] = create_params[:confirm].to_s
+    end
+
+    redirect_to root_path
+  end
+
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def create_params
+    params.permit(:command, :confirm)
+  end
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -57,6 +57,17 @@
     </div>
     <% end %>
   <% end %>
+  <% Settings.pl_sql_jobs.each_with_index do |(k,v),i| %>
+    <% if v.sunet_ids.include?(current_user.user_id) %>
+    <p></p>
+    <div class="panel panel-default">
+      <div class="panel-heading" role="tab">
+        <h4 class="link" role="button" data-toggle="collapse" href="#buttonCollapse<%= i %>" aria-expanded="false" aria-controls="buttonCollapse<%= i %>"><%= v.text %></h4>
+        <button id="buttonCollapse<%= i %>" class="collapse btn btn-md btn-default" aria-labelledby="buttonCollapse<%= i %>"><%= link_to "Run", pl_sql_job_create_path(command: v.command, confirm: v.confirm) %></button>
+      </div>
+    </div>
+    <% end %>
+  <% end %>
   <% if can? :manage, Ckey2bibframe %>
   <p></p>
   <div class="panel panel-default">

--- a/config/initializers/oracle.rb
+++ b/config/initializers/oracle.rb
@@ -1,7 +1,7 @@
 # Set time zone in TZ environment variable so that the same timezone will be used by Ruby and by Oracle session
 ENV['TZ'] = 'PST'
 
-if Rails.env.development? || Rails.env.production? 
+if Rails.env.development? || Rails.env.production?
   ActiveSupport.on_load(:active_record) do
     ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.class_eval do
       # id columns and columns which end with _id will always be converted to integers
@@ -18,6 +18,9 @@ if Rails.env.development? || Rails.env.production?
 
       # Use old visitor for Oracle 12c database
       # self.use_old_oracle_visitor = true
+
+      # Initialize ruby-plsql gem here
+      plsql.activerecord_class = ActiveRecord::Base
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,6 @@ Rails.application.routes.draw do
   resources :userload_reruns, only: [:new, :create]
   resources :ckey2bibframes, only: [:new, :create, :show], param: :ckey
 
-
   get 'shelf_selection_reports/home_locations' => 'shelf_selection_reports#home_locations', as: :home_locations_for_library
   get 'shelf_selection_reports/load_saved_options' => 'shelf_selection_reports#load_saved_options', as: :load_saved_options
   get 'circulation_statistics_reports/home_locations' => 'circulation_statistics_reports#home_locations', as: :home_locations_for_libraries
@@ -36,6 +35,7 @@ Rails.application.routes.draw do
   get 'review_batches' => 'sal3_batch_requests#review_batches'
   get 'management_reports' => 'management_reports#index'
 
+  get 'pl_sql_job/create' => 'pl_sql_job#create'
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -7,3 +7,23 @@ symphony_catalogdump: '/s/sirsi/Unicorn/Bin/catalogdump -om -kc -h -z -j -n dump
 #       It contains the tag listing '001' which instructs the catalogdump to remove all '001' fields of
 #       the MARC record. The -kc flag then adds back in an '001' field with the ckey as the value
 base_uri: 'http://ld4p-dev.stanford.edu/'
+# PL/SQL jobs
+pl_sql_jobs:
+  circ_stats_job:
+    text: 'Run circ stats reports now'
+    confirm: 'Circ stats reports started'
+    command: 'circ_stats_rpt.daily_processing'
+    sunet_ids:
+      - 'jgreben'
+      - 'dlrueda'
+      - 'sdoljack'
+      - 'mahmed'
+  delphi_pay_test_job:
+    text: 'Delphi payment test run'
+    confirm: 'Delphi payment test run started'
+    command: 'delphi_pay.test_run'
+    sunet_ids:
+      - 'jgreben'
+      - 'dlrueda'
+      - 'sdoljack'
+      - 'mahmed'

--- a/spec/controllers/pl_sql_job_controller_spec.rb
+++ b/spec/controllers/pl_sql_job_controller_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe PlSqlJobController, type: :controller do
+  describe 'GET#create' do
+    it 'gets the corrrect pl_sql_job params' do
+      get :create, params: ActionController::Parameters.new(command: 'test_command', confirm: 'Test')
+      expect(response).to have_http_status(302)
+    end
+  end
+end


### PR DESCRIPTION
Based on the configuration of a pl_sql_job in the settings yaml file, e.g.:
```
pl_sql_jobs:
  circ_stats_job:
    text: 'Circ stats report daily processing'
    command: 'circ_stats_rpt.daily_processing'
    sunet_ids:
      - 'nismoser'
      - 'jgreben'
```
links with collapsed "Run" buttons will automatically be created on the home page and will only appear for the people listed in the `sunet_ids` section of the config. Clicking the "Run" link will execute the PL/SQL job via the already configures OCI8 connection gem using the database.yml connection details. If more jobs need to be added in the future, we just fill out a new section under the `pl_sql_jobs` section.