### PR TITLE
Make sure 'mail to' field in webforms mailer gets a comma-seperated string

### DIFF
--- a/app/mailers/webforms_mailer.rb
+++ b/app/mailers/webforms_mailer.rb
@@ -5,9 +5,10 @@ class WebformsMailer < ApplicationMailer
     @duplicates = duplicates
     all_recipients = ['sul-unicorn-devs@lists.stanford.edu']
     if @uni_updates_batch.user_email
-      form_recipients = @uni_updates_batch.user_email.split(',')
-      all_recipients << form_recipients
+      form_recipients = @uni_updates_batch.user_email.split(/[\s,;]+/)
+      form_recipients.each { |r| all_recipients << r.strip }
     end
+    all_recipients.join(',')
     mail(to: all_recipients, subject: 'Batch update request')
   end
 
@@ -15,9 +16,10 @@ class WebformsMailer < ApplicationMailer
     @uni_updates_batch = uni_updates_batch
     all_recipients = ['sul-unicorn-devs@lists.stanford.edu']
     if @uni_updates_batch.user_email
-      form_recipients = @uni_updates_batch.user_email.split(',')
-      all_recipients << form_recipients
+      form_recipients = @uni_updates_batch.user_email.split(/[\s,;]+/)
+      form_recipients.each { |r| all_recipients << r.strip }
     end
+    all_recipients.join(',')
     mail(to: all_recipients, subject: 'Batch update deletion')
   end
 end

--- a/app/models/change_current_location.rb
+++ b/app/models/change_current_location.rb
@@ -4,6 +4,7 @@
 class ChangeCurrentLocation
   include FileParser
   include ActiveModel::Model
+  include ActiveModel::Validations::Callbacks
   attr_accessor :current_library
   attr_accessor :new_current_location
   attr_accessor :new_item_type
@@ -17,4 +18,5 @@ class ChangeCurrentLocation
   attr_accessor :export_yn
   attr_accessor :check_bc_first
   validates :current_library, :new_current_location, :item_ids, presence: true
+  validates :email, format: { with: Rails.configuration.email_pattern }, allow_blank: true
 end

--- a/app/models/change_home_location.rb
+++ b/app/models/change_home_location.rb
@@ -18,4 +18,5 @@ class ChangeHomeLocation
   attr_accessor :export_yn
   attr_accessor :check_bc_first
   validates :current_library, :new_home_location, :item_ids, presence: true
+  validates :email, format: { with: Rails.configuration.email_pattern }, allow_blank: true
 end

--- a/app/models/change_item_type.rb
+++ b/app/models/change_item_type.rb
@@ -18,6 +18,6 @@ class ChangeItemType
   attr_accessor :new_homeloc
   attr_accessor :new_curloc
   attr_accessor :check_bc_first
-
   validates :current_library, :new_item_type, :item_ids, presence: true
+  validates :email, format: { with: Rails.configuration.email_pattern }, allow_blank: true
 end

--- a/app/models/circulation_statistics_report.rb
+++ b/app/models/circulation_statistics_report.rb
@@ -23,10 +23,7 @@ class CirculationStatisticsReport
   validate :lc_call_hi, if: :lc_range_type?
   validate :classic_call_lo_and_hi, if: :classic_range_type?
   validate :classic_call_alpha, if: :classic_range_type?
-
-  before_validation do
-    email.tr!(' ', ',')
-  end
+  validates :email, format: { with: Rails.configuration.email_pattern }, allow_blank: true
 
   private
 

--- a/app/models/circulation_statistics_report_log.rb
+++ b/app/models/circulation_statistics_report_log.rb
@@ -8,7 +8,6 @@ class CirculationStatisticsReportLog < ActiveRecord::Base
     if circ_stats.barcodes
       FileUtils.chmod 0o664, circ_stats.barcodes.tempfile.path
       symphony_location = '/symphony/Dataload/Uploads/CircStats'
-      # user = circ_stats.email.split('@')[0]
       file_path = "#{symphony_location}/#{circ_stats.user_id}_#{circ_stats.barcodes.original_filename}"
       FileUtils.mv circ_stats.barcodes.tempfile.path, file_path
     end

--- a/app/models/encumbrance_report.rb
+++ b/app/models/encumbrance_report.rb
@@ -8,6 +8,7 @@ class EncumbranceReport < ActiveRecord::Base
   validates :email, presence: true
   validates :fund, presence: true, if: 'fund_begin.nil?'
   validates :fund_begin, presence: true, if: 'fund.nil?'
+  validates :email, format: { with: Rails.configuration.email_pattern }, allow_blank: true
 
   before_save :set_fund, :write_dates, :set_email, :set_output_file
 

--- a/app/models/endowed_funds_report.rb
+++ b/app/models/endowed_funds_report.rb
@@ -15,6 +15,7 @@ class EndowedFundsReport
   validates :cal_start, presence: true, if: 'fy_start.blank? && pd_start.blank?'
   validates :pd_start, presence: true, if: 'cal_start.blank? && fy_start.blank?'
   validates :email, presence: true
+  validates :email, format: { with: Rails.configuration.email_pattern }, allow_blank: true
 
   # get cat keys
   def self.ol_cat_key_fund(fund, date_start, date_end)

--- a/app/models/expenditure_report.rb
+++ b/app/models/expenditure_report.rb
@@ -9,6 +9,7 @@ class ExpenditureReport < ActiveRecord::Base
   validates :fund, presence: true, if: 'fund_begin.nil?'
   validates :fund_begin, presence: true, if: 'fund.nil?'
   validates :date_type, inclusion: %w(fiscal calendar paydate)
+  validates :email, format: { with: Rails.configuration.email_pattern }, allow_blank: true
 
   before_save :set_fund, :write_dates, :set_output_file
   before_save :check_fy, if: 'date_type == "fiscal"'

--- a/app/models/shelf_selection_report.rb
+++ b/app/models/shelf_selection_report.rb
@@ -21,6 +21,7 @@ class ShelfSelectionReport
   validates :format_array, length: { minimum: 2, message: "can't be empty" }, if: :other_range_type?
   validates :format_array, length: { minimum: 2, message: "can't be empty" }, if: :other_range_type?
   validates :subj_name, length: { maximum: 80, message: 'no more than 80 characters' }
+  validates :email, format: { with: Rails.configuration.email_pattern }, allow_blank: true
 
   def self.generic_options
     [["Doesn't matter", 0], ['INCLUDE only', 1], ['EXCLUDE', 2]]

--- a/app/models/transfer_item.rb
+++ b/app/models/transfer_item.rb
@@ -9,4 +9,5 @@ class TransferItem
                 :priority, :export_yn, :check_bc_first
   validates :current_library, :new_library, :new_homeloc, :item_ids,
             presence: true
+  validates :email, format: { with: Rails.configuration.email_pattern }, allow_blank: true
 end

--- a/app/models/withdraw_item.rb
+++ b/app/models/withdraw_item.rb
@@ -7,4 +7,5 @@ class WithdrawItem
   attr_accessor :current_library, :item_ids, :email, :comments, :load_date,
                 :user_name, :action, :priority, :export_yn, :check_bc_first
   validates :current_library, :item_ids, presence: true
+  validates :email, format: { with: Rails.configuration.email_pattern }, allow_blank: true
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,5 +32,6 @@ module LibsysWebforms
     config.active_record.raise_in_transactional_callbacks = true
     config.autoload_paths += %W(#{config.root}/lib)
     config.sass.load_paths << File.expand_path('../../vendor/assets/stylesheets/')
+    config.email_pattern = /(\A([\w\.%\+\-]+)@([\w\-]+\.)([\w]{2,}\s*)([;,\s]+([\w\.%\+\-]+)@([\w\-]+\.)([\w]{2,}))*\z)/i
   end
 end

--- a/spec/factories/uni_updates_batches.rb
+++ b/spec/factories/uni_updates_batches.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     batch_id 1
     batch_date '2016-05-02 16:06:56'
     user_name 'Library User'
-    user_email 'libraryuser@stanford.edu'
+    user_email 'libraryuser@stanford.edu, otheruser@stanford.edu'
     action 'TRANSFER'
     priority 1
     export_yn 'no_socI'

--- a/spec/mailers/webforms_mailer_spec.rb
+++ b/spec/mailers/webforms_mailer_spec.rb
@@ -4,15 +4,42 @@ describe WebformsMailer do
   describe 'batch update and delete mail' do
     let(:uni_updates_batch) { FactoryGirl.create(:uni_updates_batch) }
     let(:uni_updates_batch_w_no_user) { FactoryGirl.create(:uni_updates_batch, user_email: '') }
+    let(:uni_updates_batch_w_emails) do
+      FactoryGirl.build(:uni_updates_batch, user_email: 'libraryuser@stanford.edu,
+                                                         otheruser@stanford.edu
+                                                         anotheruser@stanford.edu;
+                                                         lastuser@stanford.edu')
+    end
+
     let(:upload_mail) { WebformsMailer.batch_upload_email(uni_updates_batch, ['123']) }
     let(:upload_mail_no_user) { WebformsMailer.batch_upload_email(uni_updates_batch_w_no_user, ['123']) }
     let(:delete_mail) { WebformsMailer.batch_delete_email(uni_updates_batch) }
     let(:delete_mail_no_user) { WebformsMailer.batch_delete_email(uni_updates_batch_w_no_user) }
+    let(:upload_mail_w_emails) { WebformsMailer.batch_upload_email(uni_updates_batch_w_emails, ['123']) }
+    let(:delete_mail_w_emails) { WebformsMailer.batch_delete_email(uni_updates_batch_w_emails) }
 
     describe 'to' do
       it 'is the list email address and email_user' do
-        expect(upload_mail.to).to eq ['sul-unicorn-devs@lists.stanford.edu', 'libraryuser@stanford.edu']
-        expect(delete_mail.to).to eq ['sul-unicorn-devs@lists.stanford.edu', 'libraryuser@stanford.edu']
+        expect(upload_mail.to).to eq ['sul-unicorn-devs@lists.stanford.edu',
+                                      'libraryuser@stanford.edu',
+                                      'otheruser@stanford.edu']
+        expect(delete_mail.to).to eq ['sul-unicorn-devs@lists.stanford.edu',
+                                      'libraryuser@stanford.edu',
+                                      'otheruser@stanford.edu']
+      end
+
+      it 'replaces spaces, commas, and semicolons' do
+        expect(upload_mail_w_emails.to).to eq ['sul-unicorn-devs@lists.stanford.edu',
+                                               'libraryuser@stanford.edu',
+                                               'otheruser@stanford.edu',
+                                               'anotheruser@stanford.edu',
+                                               'lastuser@stanford.edu']
+
+        expect(delete_mail_w_emails.to).to eq ['sul-unicorn-devs@lists.stanford.edu',
+                                               'libraryuser@stanford.edu',
+                                               'otheruser@stanford.edu',
+                                               'anotheruser@stanford.edu',
+                                               'lastuser@stanford.edu']
       end
 
       it 'is just the email address when no email_user is specified' do

--- a/spec/models/change_current_location_spec.rb
+++ b/spec/models/change_current_location_spec.rb
@@ -12,4 +12,25 @@ RSpec.describe ChangeCurrentLocation, type: :model do
       expect(change_item_type.parse_uploaded_file).to be_kind_of(Array)
     end
   end
+
+  describe 'valid email' do
+    it 'passes the email validation with valid email string' do
+      change_location = ChangeCurrentLocation.new
+      change_location.email = 'one@one.com two@two.ca;three@four.net, five@six.com seven@eight.it'
+      change_location.valid?
+      expect(change_location.errors[:email]).not_to include('is invalid')
+    end
+    it 'passes the email validation with empty email string' do
+      change_location = ChangeCurrentLocation.new
+      change_location.email = ''
+      change_location.valid?
+      expect(change_location.errors[:email]).not_to include('is invalid')
+    end
+    it 'fails the email validation with invalid email string' do
+      change_location = ChangeCurrentLocation.new
+      change_location.email = 'one@one.comtwo@two.ca;three@four.net, five@six seven@eight.it'
+      change_location.valid?
+      expect(change_location.errors[:email]).to include('is invalid')
+    end
+  end
 end


### PR DESCRIPTION
Previously it was receiving a an array with a nested array, e.g. `["sul-unicorn-devs@lists.stanford.edu", ["libraryuser@stanford.edu", " otheruser@stanford.edu"]]`.  Now it gets: `"sul-unicorn-devs@lists.stanford.edu,libraryuser@stanford.edu,otheruser@stanford.edu" ` Which will fix the problems with the emails as noted in #390.

This PR will also add a validation for the form of an email address if any text is supplied by the user in the `:email` field.