### PR TITLE
Do not show Upload a batch menu if user does not have permissions

### DIFF
--- a/app/views/batch_record_updates/index.html.erb
+++ b/app/views/batch_record_updates/index.html.erb
@@ -1,20 +1,22 @@
 <div class="home-page-section">
   <h1>Batch Record Updates</h1>
   <% if current_user %>
-  <h3>What would you like to do?</h3>
+  <h3>What would you like to do? </h3>
   <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
-    <div class="panel panel-default">
-      <div class="panel-heading" role="tab" id="headingOne">
-        <h4 class="panel-title">
-          <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
-            Upload a batch
-          </a>
-        </h4>
-      </div>
-      <div id="collapseOne" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingOne">
-        <%= render partial: 'upload_batch_menu' %>
-      </div>
-    </div>
+    <% if /[AY]/ === current_user.unicorn_updates %>
+     <div class="panel panel-default">
+       <div class="panel-heading" role="tab" id="headingOne">
+         <h4 class="panel-title">
+           <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+             Upload a batch
+           </a>
+         </h4>
+       </div>
+       <div id="collapseOne" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingOne">
+         <%= render partial: 'upload_batch_menu' %>
+       </div>
+     </div>
+     <% end %>
     <div class="panel panel-default">
       <div class="panel-heading" role="tab" id="headingTwo">
         <h4 class="panel-title">


### PR DESCRIPTION
We should not show the Upload a batch menu if the user does not have permission in the authorized_user table to access any of those links.