### PR TITLE
On deploy fetch v1.0.2 of the xform-marc21-to-xml jar file

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -58,9 +58,10 @@ namespace :deploy do
   after :restart, :clear_cache do
     on roles(:web), in: :groups, limit: 3, wait: 10 do
       # Here we can do anything such as:
-      # within release_path do
-      #   execute :rake, 'cache:clear'
-      # end
+      within release_path do
+        execute "cd #{release_path.join('lib')} && \
+          curl -sOL https://github.com/sul-dlss/ld4p-marc21-to-xml/releases/download/v1.0.2/xform-marc21-to-xml-jar-with-dependencies.jar"
+      end
     end
   end
 


### PR DESCRIPTION
With this PR we will no longer need to manually copy the xform-marc21-to-xml-jar-with-dependencies.jar file from the app root into the libsys-webforms/current/lib directory. This will happen automatically when deploying.