### PR TITLE
Encumb fiscali

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,4 +22,12 @@ module ApplicationHelper
       class: 'btn btn-md btn-default btn-full'
     ), new_ckey2bibframe_path
   end
+
+  def fiscal_years
+    Date.fy_start_month = 9
+    Date.use_forward_year!
+    financial_year = Time.zone.today.financial_year.to_s
+    cyc = ('2000'..financial_year).to_a.reverse
+    cyc.push('9899', '9798', '9697')
+  end
 end

--- a/app/models/encumbrance_report.rb
+++ b/app/models/encumbrance_report.rb
@@ -14,11 +14,6 @@ class EncumbranceReport < ActiveRecord::Base
 
   self.table_name = 'encumbrance_rpts'
 
-  def self.fundcyc_cycle
-    cyc = ('2000'..Time.zone.now.strftime('%Y')).to_a.reverse
-    cyc.push('9899', '9798', '9697')
-  end
-
   def kickoff
     ActiveRecord::Base.connection.execute("begin encumb_rpt.run_rpt('#{output_file}'); end;")
   rescue ActiveRecord::StatementInvalid

--- a/app/models/expenditures_paydates.rb
+++ b/app/models/expenditures_paydates.rb
@@ -9,14 +9,6 @@ class ExpendituresPaydates < ActiveRecord::Base
     ('1996'..Time.zone.now.strftime('%Y')).to_a.reverse
   end
 
-  def self.fiscal_years
-    Date.fy_start_month = 9
-    Date.use_forward_year!
-    financial_year = Time.zone.today.financial_year.to_s
-    cyc = ('2000'..financial_year).to_a.reverse
-    cyc.push('9899', '9798', '9697')
-  end
-
   def self.pay_dates
     order(pay_date: :desc)
   end

--- a/app/views/encumbrance_reports/new.html.erb
+++ b/app/views/encumbrance_reports/new.html.erb
@@ -24,7 +24,7 @@
   <div class='form-group row'>
     <%= f.label :fundcyc_cycle, 'Fiscal Cycle:', class: 'col-sm-3 form-control-label' %>
     <div class='col-sm-10'>
-      <%= f.select :fundcyc_cycle, options_for_select(EncumbranceReport.fundcyc_cycle.map{ |b| [ b ] }), {}, {class: 'form-control'} %>
+      <%= f.select :fundcyc_cycle, options_for_select(fiscal_years.map{ |b| [ b ] }), {}, {class: 'form-control'} %>
     </div>
   </div>
 

--- a/app/views/shared/_date_range_selection.html.erb
+++ b/app/views/shared/_date_range_selection.html.erb
@@ -22,10 +22,10 @@
     <div class='panel-body fiscal collapse'>
       <div class='form-group'>
         <div class='col-sm-3'>First payment date:
-          <%= f.select :fy_start, options_for_select(ExpendituresPaydates.fiscal_years.map{ |d| [ "FY #{d}" ] }), {include_blank: 'Choose FY Start'}, {class: 'form-control'} %>
+          <%= f.select :fy_start, options_for_select(fiscal_years.map{ |d| [ "FY #{d}" ] }), {include_blank: 'Choose FY Start'}, {class: 'form-control'} %>
         </div>
         <div class='col-sm-3'>Last payment date:
-          <%= f.select :fy_end, options_for_select(ExpendituresPaydates.fiscal_years.map{ |d| [ "FY #{d}" ] }), {include_blank: 'Same FY as Start'}, {class: 'form-control'} %>
+          <%= f.select :fy_end, options_for_select(fiscal_years.map{ |d| [ "FY #{d}" ] }), {include_blank: 'Same FY as Start'}, {class: 'form-control'} %>
         </div>
       </div>
     </div>

--- a/spec/models/encumbrance_report_spec.rb
+++ b/spec/models/encumbrance_report_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe EncumbranceReport, type: :model do
     expect(FactoryGirl.create(:encumbrance_report)).to be_valid
   end
   it 'Defines a list of fund cycles' do
-    expect(EncumbranceReport.fundcyc_cycle).to include('2015', '9899', '9798', '9697')
+    expect(fiscal_years).to include('2015', '9899', '9798', '9697')
   end
 
   describe 'callbacks' do

--- a/spec/models/expenditure_paydates_spec.rb
+++ b/spec/models/expenditure_paydates_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ExpendituresPaydates, type: :model do
     end
 
     it 'Defines a list of fiscal years' do
-      expect(ExpendituresPaydates.fiscal_years).to include('9899', '9798', '9697', '2015', @financial_year)
+      expect(fiscal_years).to include('9899', '9798', '9697', '2015', @financial_year)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,7 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.include ApplicationHelper
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin


### PR DESCRIPTION
Adds new fiscal year using fiscal gem for encumbrance report and DRY's up fiscal_years method called by both expenditure and encumbrance reports to application helper.

Fixes tests for new encumberance report fiscal years/dry'd up fiscal years.