### PR TITLE
Make sure call letters are uppercase if they are submitted in the form

### DIFF
--- a/app/models/circulation_statistics_report.rb
+++ b/app/models/circulation_statistics_report.rb
@@ -25,7 +25,17 @@ class CirculationStatisticsReport
   validate :classic_call_alpha, if: :classic_range_type?
   validates :email, format: { with: Rails.configuration.email_pattern }, allow_blank: true
 
+  before_validation :upcase_call_alpha
+
   private
+
+  def upcase_call_alpha
+    call_alpha.upcase! unless call_alpha.nil?
+  end
+
+  def upcase_call_lo
+    call_lo.upcase! unless call_lo.nil?
+  end
 
   def barcode_range_type?
     range_type == 'barcodes'

--- a/app/models/circulation_statistics_report.rb
+++ b/app/models/circulation_statistics_report.rb
@@ -30,11 +30,11 @@ class CirculationStatisticsReport
   private
 
   def upcase_call_alpha
-    call_alpha.upcase! unless call_alpha.nil?
+    call_alpha && call_alpha.upcase!
   end
 
   def upcase_call_lo
-    call_lo.upcase! unless call_lo.nil?
+    call_lo && call_lo.upcase!
   end
 
   def barcode_range_type?


### PR DESCRIPTION
The circulation_statistics_report validation expects uppercase call letters, so make sure that they are always upper-case.