### PR TITLE
Include sal3contact@stanford.edu

### DIFF
--- a/app/mailers/webforms_mailer.rb
+++ b/app/mailers/webforms_mailer.rb
@@ -3,7 +3,7 @@ class WebformsMailer < ApplicationMailer
   def batch_upload_email(uni_updates_batch, duplicates)
     @uni_updates_batch = uni_updates_batch
     @duplicates = duplicates
-    all_recipients = ['sul-unicorn-devs@lists.stanford.edu']
+    all_recipients = ['sul-unicorn-devs@lists.stanford.edu, sal3contact@stanford.edu']
     if @uni_updates_batch.user_email
       form_recipients = @uni_updates_batch.user_email.split(/[\s,;]+/)
       form_recipients.each { |r| all_recipients << r.strip }

--- a/spec/mailers/webforms_mailer_spec.rb
+++ b/spec/mailers/webforms_mailer_spec.rb
@@ -21,6 +21,7 @@ describe WebformsMailer do
     describe 'to' do
       it 'is the list email address and email_user' do
         expect(upload_mail.to).to eq ['sul-unicorn-devs@lists.stanford.edu',
+                                      'sal3contact@stanford.edu',
                                       'libraryuser@stanford.edu',
                                       'otheruser@stanford.edu']
         expect(delete_mail.to).to eq ['sul-unicorn-devs@lists.stanford.edu',
@@ -30,6 +31,7 @@ describe WebformsMailer do
 
       it 'replaces spaces, commas, and semicolons' do
         expect(upload_mail_w_emails.to).to eq ['sul-unicorn-devs@lists.stanford.edu',
+                                               'sal3contact@stanford.edu',
                                                'libraryuser@stanford.edu',
                                                'otheruser@stanford.edu',
                                                'anotheruser@stanford.edu',
@@ -43,7 +45,8 @@ describe WebformsMailer do
       end
 
       it 'is just the email address when no email_user is specified' do
-        expect(upload_mail_no_user.to).to eq ['sul-unicorn-devs@lists.stanford.edu']
+        expect(upload_mail_no_user.to).to eq ['sul-unicorn-devs@lists.stanford.edu',
+                                              'sal3contact@stanford.edu']
         expect(delete_mail_no_user.to).to eq ['sul-unicorn-devs@lists.stanford.edu']
       end
     end


### PR DESCRIPTION
... as a default notification email address for sal3_batch_request submissions.

Fixes #456 