### PR TITLE
Differentiates apps users can administer versus access.

### DIFF
--- a/app/controllers/authorized_users_controller.rb
+++ b/app/controllers/authorized_users_controller.rb
@@ -52,8 +52,11 @@ class AuthorizedUsersController < ApplicationController
 
   def delete
     @authorized_user ||= AuthorizedUser.find_by(user_id: params[:user_id])
-    @authorized_user.destroy
-    flash[:notice] = 'User deleted!'
+    if @authorized_user.destroy
+      flash[:notice] = 'User deleted!'
+    else
+      flash[:error] = 'User has access to other forms and cannot be deleted!'
+    end
     redirect_to authorized_users_index_path
   end
 

--- a/app/helpers/authorized_user_helper.rb
+++ b/app/helpers/authorized_user_helper.rb
@@ -3,10 +3,19 @@
 #######
 module AuthorizedUserHelper
   # get column names for user which contains "A"
+  def administrator_apps(user)
+    administrator_apps = []
+    user.attributes.each do |k, v|
+      administrator_apps.push(k) if v == 'A'
+    end
+    administrator_apps
+  end
+
+  # get column names for user which contains "Y"
   def authorized_apps(user)
     authorized_apps = []
     user.attributes.each do |k, v|
-      authorized_apps.push(k) if v == 'A'
+      authorized_apps.push(k) if v == 'Y'
     end
     authorized_apps
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -30,7 +30,7 @@ class Ability
 
   def assign_admin_permission(current_user)
     can :manage, AccessionNumber if /A/ =~ current_user.accession_number
-    app = AuthorizedUsersController.helpers.authorized_apps(current_user)
+    app = AuthorizedUsersController.helpers.administrator_apps(current_user)
     can :manage, AuthorizedUser if app.any?
   end
 

--- a/app/models/authorized_user.rb
+++ b/app/models/authorized_user.rb
@@ -8,11 +8,20 @@ class AuthorizedUser < ActiveRecord::Base
 
   validates :user_id, :user_name, presence: true
 
-  before_destroy :non_admin_user?
+  before_destroy :app_user?
 
   private
 
+  def app_user?
+    # No Y or A in any AuthorizedUser table column.
+    non_admin_user? && admin_user?
+  end
+
   def non_admin_user?
     authorized_apps(AuthorizedUser.find_by(user_id: user_id)).empty?
+  end
+
+  def admin_user?
+    administrator_apps(AuthorizedUser.find_by(user_id: user_id)).empty?
   end
 end

--- a/app/views/authorized_users/_authorized_user_header.html.erb
+++ b/app/views/authorized_users/_authorized_user_header.html.erb
@@ -2,7 +2,7 @@
   <div class="div-table-row">
     <div class="div-table-head">SUNet ID</div>
     <div class="div-table-head">Name</div>
-    <% authorized_apps(current_user).each do |app| %>
+    <% administrator_apps(current_user).each do |app| %>
       <div class="div-table-head"><%= apps_translation(app) %></div>
     <% end %>
   </div>

--- a/app/views/authorized_users/_new.html.erb
+++ b/app/views/authorized_users/_new.html.erb
@@ -18,7 +18,7 @@
           <%= f.text_field :user_name %>
         </div>
         <% @authorized_user.attributes.each do |k,v| %>
-          <% if authorized_apps(current_user).include?(k) %>
+          <% if administrator_apps(current_user).include?(k) %>
             <div class="div-table-cell">
               <%= f.check_box(k, {}, "Y", "") %>
             </div>

--- a/app/views/authorized_users/edit.html.erb
+++ b/app/views/authorized_users/edit.html.erb
@@ -23,7 +23,7 @@
       </div>
       <!-- disable checkbox if the value is 'A' -->
       <% @authorized_user.attributes.each do |k,v| %>
-        <% if authorized_apps(current_user).include?(k) %>
+        <% if administrator_apps(current_user).include?(k) %>
           <% if v == 'A' %>
             <div class="div-table-cell">
               <%= check_box_tag(k, v, v, disabled: true) %>
@@ -43,7 +43,7 @@
   </div>
   <% end %>
 </div>
-<% if authorized_apps(@authorized_user).empty? %>
+<% if administrator_apps(@authorized_user).empty? %>
 <!-- only allow delete user if not admin user -->
 <div class="btn-group">
   <%= button_to 'Delete User', { action: :delete,

--- a/app/views/authorized_users/index.html.erb
+++ b/app/views/authorized_users/index.html.erb
@@ -11,7 +11,7 @@
     <tr>
       <th>SUNet ID</th>
       <th>Name</th>
-      <% authorized_apps(current_user).each do |app| %>
+      <% administrator_apps(current_user).each do |app| %>
         <th><%= apps_translation(app) %></th>
       <% end %>
     </tr>
@@ -23,7 +23,7 @@
         <td><%= user.user_id %></td>
         <td><%= user.user_name %></td>
         <% user.attributes.each do |k,v| %>
-          <% if authorized_apps(current_user).include?(k) %>
+          <% if administrator_apps(current_user).include?(k) %>
             <% if v == 'A' || v == 'Y'%>
               <td><%= check_box_tag(k, v, v, disabled: true) %></td>
             <% else %>

--- a/spec/controllers/authorized_users_controller_spec.rb
+++ b/spec/controllers/authorized_users_controller_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe AuthorizedUsersController, type: :controller do
     stub_current_user(FactoryBot.create(:authorized_user))
     @authorized_user = FactoryBot.create(:admin_user)
     @staff_user = FactoryBot.create(:staff_user)
+    @blank_user = FactoryBot.create(:blank_user)
   end
 
   describe 'get#index' do
@@ -65,10 +66,13 @@ RSpec.describe AuthorizedUsersController, type: :controller do
   end
   describe 'delete#delete' do
     it 'deletes a user' do
-      expect { delete :delete, user_id: @staff_user }.to change(AuthorizedUser, :count).by(-1)
+      expect { delete :delete, user_id: @blank_user }.to change(AuthorizedUser, :count).by(-1)
     end
     it 'does not delete an admin user' do
       expect { delete :delete, user_id: @authorized_user }.to change(AuthorizedUser, :count).by(0)
+    end
+    it 'does not delete a staff user that still has access to an app' do
+      expect { delete :delete, user_id: @staff_user }.to change(AuthorizedUser, :count).by(0)
     end
   end
 end

--- a/spec/factories/authorized_users.rb
+++ b/spec/factories/authorized_users.rb
@@ -59,4 +59,24 @@ FactoryBot.define do
     f.userload_rerun 'Y'
     f.accession_number 'Y'
   end
+  factory :blank_user, class: AuthorizedUser do |f|
+    f.user_id 'blank_user'
+    f.user_name 'Blank User'
+    f.unicorn_updates ''
+    f.direct_upload ''
+    f.unicorn_circ_batch ''
+    f.priv_approval ''
+    f.email_stats ''
+    f.priv_support ''
+    f.db_access_ids ''
+    f.priceforbills ''
+    f.reset_recall_counter ''
+    f.mgt_rpts ''
+    f.ora_admin ''
+    f.sal3_batch_req ''
+    f.sal3_breq_edit ''
+    f.file_upload ''
+    f.userload_rerun ''
+    f.accession_number ''
+  end
 end

--- a/spec/helpers/authorized_user_helper_spec.rb
+++ b/spec/helpers/authorized_user_helper_spec.rb
@@ -1,11 +1,25 @@
 require 'rails_helper'
 
 describe AuthorizedUserHelper do
+  describe '#administrator_apps' do
+    it 'returns a list of apps one can administer' do
+      @authorized_user = FactoryBot.create(:admin_user)
+      expect(helper.administrator_apps(@authorized_user)).to eq(%w[unicorn_updates
+                                                                   mgt_rpts
+                                                                   accession_number])
+    end
+  end
   describe '#authorized_apps' do
     it 'returns a list of authorized apps' do
-      @authorized_user = FactoryBot.create(:admin_user)
+      @authorized_user = FactoryBot.create(:staff_user)
       expect(helper.authorized_apps(@authorized_user)).to eq(%w[unicorn_updates
+                                                                direct_upload
                                                                 mgt_rpts
+                                                                ora_admin
+                                                                sal3_batch_req
+                                                                file_upload
+                                                                sal3_breq_edit
+                                                                userload_rerun
                                                                 accession_number])
     end
   end


### PR DESCRIPTION
Fixes #427 
@dlrueda @jgreben This will make it so only users with nil in all columns can be deleted. Specifically fixes the before_destroy callback: https://github.com/sul-dlss/libsys-webforms/blob/authorized-users-bug/app/models/authorized_user.rb#L11 