### PR TITLE
Allows call numbers low numeric range to be equal to the high range 

### DIFF
--- a/app/models/circulation_statistics_report.rb
+++ b/app/models/circulation_statistics_report.rb
@@ -82,7 +82,7 @@ class CirculationStatisticsReport
     lo_integer = call_lo.to_i
     hi_integer = call_hi.to_i
     message = 'Low and hi callnum range must be all digits, with lo lower than hi.'
-    errors.add(:base, message) unless call_lo =~ /^[0-9]+$/ && call_hi =~ /^[0-9]+$/ && lo_integer < hi_integer
+    errors.add(:base, message) unless call_lo =~ /^[0-9]+$/ && call_hi =~ /^[0-9]+$/ && lo_integer <= hi_integer
   end
 
   # rubocop:disable Metrics/PerceivedComplexity


### PR DESCRIPTION
This is for the classic call number option on the circ stats report.