### PR TITLE
Requires presence of batch start date on update as well as create

### DIFF
--- a/app/controllers/sal3_batch_requests_batches_controller.rb
+++ b/app/controllers/sal3_batch_requests_batches_controller.rb
@@ -51,7 +51,7 @@ class Sal3BatchRequestsBatchesController < ApplicationController
       flash[:success] = 'Batch updated!'
       redirect_to sal3_batch_requests_batches_path
     else
-      render :edit
+      render action: 'edit'
     end
   end
 

--- a/app/models/sal3_batch_requests_batch.rb
+++ b/app/models/sal3_batch_requests_batch.rb
@@ -8,8 +8,10 @@ class Sal3BatchRequestsBatch < ActiveRecord::Base
   validates :bc_file_obj, presence: { message: 'You must upload a file of barcodes' }, on: :create
   validates :batch_numpullperday, numericality: { message: 'You must enter the number of items to pull per day' },
                                   on: :update
-  validates :batch_startdate, presence: { message: 'You must enter a start date' }, on: :create
-  validates :batch_needbydate, presence: { message: 'You must enter a completion date' }, on: :create
+  validates :batch_startdate, presence: { message: 'You must enter a start date' },
+                              on: %i(create update)
+  validates :batch_needbydate, presence: { message: 'You must enter a completion date' },
+                               on: %i(create update)
   has_many :sal3_batch_request_bcs, foreign_key: 'batch_id',
                                     class_name: Sal3BatchRequestBcs,
                                     dependent: :destroy,

--- a/app/views/sal3_batch_requests_batches/edit.html.erb
+++ b/app/views/sal3_batch_requests_batches/edit.html.erb
@@ -53,7 +53,8 @@
     <div class='form-group row'>
       <%= f.label :batch_startdate, "Delivery start date:", class: 'col-sm-2 form-control-label' %>
       <div class='col-sm-10'>
-        <%= f.date_field 'batch_startdate', as: :date, class: 'form-control', value: f.object.batch_startdate.strftime('%d-%^b-%y') %>
+        <%= f.date_field 'batch_startdate', as: :date, class: 'form-control',
+            value: f.object.batch_startdate.nil? ? '' : f.object.batch_startdate.strftime('%F') %>
       </div>
     </div>
     <div class='form-group row'>

--- a/spec/controllers/sal3_batch_requests_batch_controller_spec.rb
+++ b/spec/controllers/sal3_batch_requests_batch_controller_spec.rb
@@ -69,6 +69,18 @@ RSpec.describe Sal3BatchRequestsBatchesController, type: :controller do
       @sal3_batch_requests_batch.reload
       expect(@sal3_batch_requests_batch.priority).to eq(1)
     end
+    it 'is unsuccessful returning to the edit view without required dates' do
+      @sal3_batch_requests_batch = Sal3BatchRequestsBatch.create!(bc_file_obj: barcode_file,
+                                                                  priority: 2,
+                                                                  batch_numpullperday: 10,
+                                                                  batch_startdate: '11-APR-18',
+                                                                  batch_needbydate: '11-APR-18')
+      stub_current_user(FactoryBot.create(:authorized_user))
+      put :update, id: @sal3_batch_requests_batch, sal3_batch_requests_batch: { batch_startdate: nil,
+                                                                                batch_needbydate: nil }
+      @sal3_batch_requests_batch.reload
+      expect(response).to render_template('edit')
+    end
     it 'redirects to the edit page when update fails' do
       # this spec passes, but doesn't seem to get coverage
       # sal3_batch_requests_batches_controller.rb: 1 untested lines: [40]

--- a/spec/models/sal3_batch_requests_batch_spec.rb
+++ b/spec/models/sal3_batch_requests_batch_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Sal3BatchRequestsBatch, type: :model do
     expect(Sal3BatchRequestsBatch.priority). to eq %w[1 2 3]
   end
   it 'Validates the presence of needed dates' do
-    request = FactoryBot.build(:sal3_batch_requests_batch, batch_startdate: nil, batch_needbydate: nil)
-    expect(request).not_to be_valid
+    request = Sal3BatchRequestsBatch.new(batch_startdate: nil, batch_needbydate: nil)
+    expect(request).to_not be_valid
   end
 end


### PR DESCRIPTION
HTML5 date form elements require date format in the form of yyyy-mm-dd. `%F` strftime handles this.