### PR TITLE
Edi landing page

### DIFF
--- a/app/controllers/edi_invoices_controller.rb
+++ b/app/controllers/edi_invoices_controller.rb
@@ -1,4 +1,11 @@
 # Controller for EdiInvoice management
 class EdiInvoicesController < ApplicationController
   def index; end
+
+  def invoice_exclude
+    # @EdiSomeModel = EdiSomeModel.new
+    respond_to do |format|
+      format.js # invoice_exclude.js.erb
+    end
+  end
 end

--- a/app/views/edi_invoices/_edi_updates_menu.html.erb
+++ b/app/views/edi_invoices/_edi_updates_menu.html.erb
@@ -1,0 +1,8 @@
+<div id="edi-updates-menu" class="panel-body">
+  <h5>Choose the type of batch record update you wish to do:</h5>
+  <li><%= link_to "Exclude an invoice", edi_invoices_invoice_exclude_path, :remote => true,
+              'data-toggle' => "modal", 'data-target' => '#new-modal-window' %></li>
+  <li><%= link_to "Change invoice line (PO num, fund name)", edi_invoices_change_invoice_line_path %></li>
+  <li><%= link_to "Allow a \"noBib\"", edi_invoices_allow_nobib_path %></li>
+  <li><%= link_to "Fix duplicate barcode", edi_invoices_fix_duplicate_barcode_path %></li>
+</div>

--- a/app/views/edi_invoices/_invoice_exclude.html.erb
+++ b/app/views/edi_invoices/_invoice_exclude.html.erb
@@ -1,0 +1,22 @@
+<div class="modal-header">
+   <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+   <h3 id="excludeInvoice">Exclude an invoice</h3>
+</div>
+<div class="modal-body">
+  <div class="div-table">
+    <div class="div-table-body">
+      <div class="div-table-row">
+        <div class="div-table-cell">
+
+        </div>
+        <div class="div-table-cell">
+
+        </div>
+      </div>
+    </div>
+    <div class="btn-group">
+
+      <button class='btn btn-md btn-default btn-full' data-dismiss="modal" aria-hidden="true">Cancel</button>
+    </div>
+  </div>
+</div>

--- a/app/views/edi_invoices/index.html.erb
+++ b/app/views/edi_invoices/index.html.erb
@@ -1,8 +1,43 @@
 <div class="home-page-section">
   <h1>EDIFACT invoice management</h1>
   <% if can? :read, EdiInvoice %>
+    <div id="new-modal-window" class="modal fade modal-content" role="dialog"
+         aria-labelledby="excludeInvoice" aria-hidden="true"></div>
     <h3>What would you like to do? </h3>
     <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+      <% if /[AY]/ === current_user.edi_inv_view %>
+        <div class="panel panel-default">
+          <div class="panel-heading" role="tab" id="headingOne">
+            <h4 class="panel-title">
+              <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+                Updates
+              </a>
+            </h4>
+          </div>
+          <div id="collapseOne" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingOne">
+            <%= render partial: 'edi_updates_menu' %>
+          </div>
+        </div>
+      <% end %>
+      <div class="panel panel-default">
+        <div class="panel-heading" role="tab" id="headingTwo">
+          <h4 class="panel-title">
+            <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
+              View invoices
+            </a>
+          </h4>
+        </div>
+      </div>
+      <div class="panel panel-default">
+        <div class="panel-heading" role="tab" id="headingThree">
+          <h4 class="panel-title">
+            <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
+              View errors
+            </a>
+          </h4>
+        </div>
+      </div>
+
 
     </div>
     <div class="btn-group">

--- a/app/views/edi_invoices/invoice_exclude.js.erb
+++ b/app/views/edi_invoices/invoice_exclude.js.erb
@@ -1,0 +1,1 @@
+$("#new-modal-window").html("<%= escape_javascript(render 'invoice_exclude') %>");

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,16 +23,16 @@
 <body>
 
   <div id="su-wrap"> <!-- #su-wrap start -->
-        <div id="su-content"> <!-- #su-content start -->
-          <div id="outer-container" class="container-fluid">
-            <%= render 'shared/top_navbar' %>
-            <section id="main-container" role="main">
-              <%= render 'shared/flashes' %>
-              <%= yield %>
-            </div>
-          </div>
-        </div>
+    <div id="su-content"> <!-- #su-content start -->
+      <div id="outer-container" class="container-fluid">
+        <%= render 'shared/top_navbar' %>
+        <section id="main-container" role="main">
+          <%= render 'shared/flashes' %>
+          <%= yield %>
+        </section>
       </div>
+    </div>
+  </div>
 
       <%= render 'shared/sul_footer' %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,12 @@ Rails.application.routes.draw do
   get 'show_batches_complete' => 'batch_record_updates#show_batches_complete'
   get 'show_batches_not_complete' => 'batch_record_updates#show_batches_not_complete'
   get 'review_batches' => 'sal3_batch_requests#review_batches'
+
+  get 'edi_invoices/invoice_exclude' => 'edi_invoices#invoice_exclude'
+  get 'edi_invoices/change_invoice_line' => 'edi_invoices#change_invoice_line'
+  get 'edi_invoices/allow_nobib' => 'edi_invoices#allow_nobib'
+  get 'edi_invoices/fix_duplicate_barcode' => 'edi_invoices#fix_duplicate_barcode'
+
   get 'management_reports' => 'management_reports#index'
 
   get 'by_location' => 'accession_number_updates#by_location'

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -16,6 +16,7 @@ module Constants
     'sal3_breq_edit' => 'Edit SAL3 batch requests',
     'unicorn_updates' => 'Symphony batch updates',
     'unicorn_circ_batch' => 'Symphony circulation batches',
-    'userload_rerun' => 'Userload reruns'
+    'userload_rerun' => 'Userload reruns',
+    'edi_inv_manage' => 'EDI Invoices'
   }.freeze
 end

--- a/spec/controllers/edi_invoices_controller_spec.rb
+++ b/spec/controllers/edi_invoices_controller_spec.rb
@@ -8,4 +8,10 @@ RSpec.describe EdiInvoicesController, type: :controller do
       expect(response).to be_successful
     end
   end
+  describe 'get#invoice_exclude' do
+    it 'renders new modal to exclude an invoice' do
+      xhr :get, 'invoice_exclude'
+      expect(response.headers['Content-Type']).to eq 'text/javascript; charset=utf-8'
+    end
+  end
 end

--- a/spec/views/edi_invoices/index.html.erb_spec.rb
+++ b/spec/views/edi_invoices/index.html.erb_spec.rb
@@ -28,5 +28,21 @@ RSpec.describe 'edi_invoices/index', type: :view do
     it 'should display the page header' do
       assert_select 'h3', text: 'What would you like to do?'.to_s
     end
+    it 'should display the page header' do
+      assert_select 'a', text: 'Exclude an invoice'.to_s,
+                         href: edi_invoices_invoice_exclude_path
+    end
+    it 'should display the page header' do
+      assert_select 'a', text: 'Change invoice line (PO num, fund name)'.to_s,
+                         href: edi_invoices_change_invoice_line_path
+    end
+    it 'should display the page header' do
+      assert_select 'a', text: 'Allow a "noBib"'.to_s,
+                         href: edi_invoices_allow_nobib_path
+    end
+    it 'should display the page header' do
+      assert_select 'a', text: 'Fix duplicate barcode'.to_s,
+                         href: edi_invoices_fix_duplicate_barcode_path
+    end
   end
 end


### PR DESCRIPTION
Fixes #369 
Adds a basic landing page for EDI Invoices.

`Exclude an invoice` will currently open a blank modal window

Currently the following will lead to an `Unknown action` error page because there are as yet no controller actions or views defined:
```
Change invoice line
Allow a "noBib"
Fix duplicate barcode
```

Staff users and managers do not have access to `edi_inv_manage` or `edi_inv_view` in production, so they will not see these links or the aforementioned error...