### PR TITLE
Fix edi dates

### DIFF
--- a/app/assets/javascripts/edi_error_reports.js
+++ b/app/assets/javascripts/edi_error_reports.js
@@ -1,27 +1,8 @@
 // Place all the behaviors and hooks related to the matching controller here.
 // All this logic will automatically be available in application.js.
-jQuery(document).ready(function($) {
-    jQuery.extend( jQuery.fn.dataTableExt.oSort, {
-        "date-uk-pre": function ( a ) {
-            var ukDatea = a.split('/');
-            var yearWithoutTime = ukDatea[2].split(' ')[0];
-            return (yearWithoutTime + ukDatea[1] + ukDatea[0]) * 1;
-        },
-        "date-uk-asc": function ( a, b ) {
-            console.log("asc");
-            return ((a < b) ? -1 : ((a > b) ? 1 : 0));
-        },
-        "date-uk-desc": function ( a, b ) {
-            console.log("desc");
-            return ((a < b) ? 1 : ((a > b) ? -1 : 0));
-        }
-    } );
-
+$(document).ready(function() {
     $('table').DataTable({
-        "order": [[ 0, "desc" ]],
-        columnDefs: [
-            { type: 'date-uk', targets: 0 } // define 'run' column as date
-        ]
+        "order": [[ 0, "desc" ]]
     });
 
     $('input#edi_errors_day').on('change', function() {

--- a/app/controllers/edi_error_reports_controller.rb
+++ b/app/controllers/edi_error_reports_controller.rb
@@ -6,7 +6,7 @@ class EdiErrorReportsController < ApplicationController
   has_scope :type
 
   def index
-    @edi_error_report = apply_scopes(EdiErrorReport).all
+    @edi_error_report = apply_scopes(EdiErrorReport.order(run: :desc)).all
   rescue StandardError => e
     flash[:error] = e.message
     redirect_to edi_error_reports_path

--- a/app/models/edi_error_report.rb
+++ b/app/models/edi_error_report.rb
@@ -4,9 +4,9 @@ class EdiErrorReport < ActiveRecord::Base
   # which rails uses to define the subclass of a model that should be loaded.
   self.inheritance_column = 'inheritance_type'
 
-  scope :day, ->(day) { where(date_query, day.to_date) }
-  scope :level, ->(level) { where(err_lvl: level) }
-  scope :type, ->(type) { where(type: type) }
+  scope :day, ->(day) { where(date_query, day.to_date).order(run: :desc) }
+  scope :level, ->(level) { where(err_lvl: level).order(run: :desc) }
+  scope :type, ->(type) { where(type: type).order(run: :desc) }
 
   self.table_name = 'edi_error_report'
 

--- a/app/views/edi_error_reports/index.html.erb
+++ b/app/views/edi_error_reports/index.html.erb
@@ -25,7 +25,7 @@
     <tbody>
     <% @edi_error_report.each do |eer| %>
       <tr class='<%= cycle("odd", "even") %>'>
-        <td><%= eer.run.present? ? eer.run.strftime('%x %H:%M') : '' %></td>
+        <td><%= eer.run.present? ? eer.run.strftime('%Y-%m-%d %H:%M') : '' %></td>
         <td><%= eer.type %></td>
         <td><%= eer.error %></td>
         <td><%= eer.err_lvl %></td>

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,7 @@ module LibsysWebforms
     config.autoload_paths += %W(#{config.root}/lib)
     config.sass.load_paths << File.expand_path('../../vendor/assets/stylesheets/')
     config.time_zone = 'Pacific Time (US & Canada)'
+    config.active_record.default_timezone = :local
     config.email_pattern = /(\A([\w\.%\+\-]+)@([\w\-]+\.)([\w]{2,}\s*)([;,\s]+([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,}))*\z)/i
   end
 end

--- a/config/initializers/oracle.rb
+++ b/config/initializers/oracle.rb
@@ -1,6 +1,3 @@
-# Set time zone in TZ environment variable so that the same timezone will be used by Ruby and by Oracle session
-ENV['TZ'] = 'PST'
-
 # This is for the rails 4.2 version. See https://github.com/rsim/oracle-enhanced#rails-42
 # When upgrading to rails 5 we can remove the deprecated self.emulate_* lines from config/initializers/oracle.rb
 if Rails.env.development? || Rails.env.production?

--- a/spec/controllers/endowed_funds_reports_controller_spec.rb
+++ b/spec/controllers/endowed_funds_reports_controller_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe EndowedFundsReportsController, type: :controller do
                  ckeys_file: 'endow123.txt' }
 
       post :create, endowed_funds_report: params
-      expect(controller.date_start).to eq '2014-12-31'
-      expect(controller.date_end).to eq '2016-12-30'
+      expect(controller.date_start).to eq '2015-01-01'
+      expect(controller.date_end).to eq '2016-12-31'
     end
     it 'creates the params for a symphony request using fund_begin string and paid dates' do
       params = { fund: nil, fund_begin: '1000501-1-AACIZ-', report_format: 'n',
@@ -51,8 +51,8 @@ RSpec.describe EndowedFundsReportsController, type: :controller do
                  ckeys_file: 'endow123.txt' }
 
       post :create, endowed_funds_report: params
-      expect(controller.date_start).to eq '1998-12-21'
-      expect(controller.date_end).to eq '1999-12-21'
+      expect(controller.date_start).to eq '1998-12-22'
+      expect(controller.date_end).to eq '1999-12-22'
     end
   end
 

--- a/spec/models/expenditure_report_spec.rb
+++ b/spec/models/expenditure_report_spec.rb
@@ -29,10 +29,10 @@ RSpec.describe ExpenditureReport, type: :model do
       expect(@report.send(:write_fy_end, '2011')).to eq('2011-AUG-25')
       expect(@report.send(:check_fy)).to eq('2011-AUG-25')
 
-      expect(@report.send(:write_cal_start, '2011')).to eq('2010-12-31')
-      expect(@report.send(:write_cal_end, '2011')).to eq('2011-12-30')
-      expect(@report.send(:write_pd_start, '04-OCT-96')).to eq('1996-OCT-03')
-      expect(@report.send(:write_pd_end, '04-OCT-97')).to eq('1997-OCT-03')
+      expect(@report.send(:write_cal_start, '2011')).to eq('2011-01-01')
+      expect(@report.send(:write_cal_end, '2011')).to eq('2011-12-31')
+      expect(@report.send(:write_pd_start, '04-OCT-96')).to eq('1996-OCT-04')
+      expect(@report.send(:write_pd_end, '04-OCT-97')).to eq('1997-OCT-04')
     end
     it 'sets the attribute for fund_acct with a fund_begin value' do
       @report.update_attributes(fund: nil)

--- a/spec/models/expenditures_with_circ_stats_report_spec.rb
+++ b/spec/models/expenditures_with_circ_stats_report_spec.rb
@@ -26,10 +26,10 @@ RSpec.describe ExpendituresWithCircStatsReport, type: :model do
       expect(@report.send(:write_fy_end, '2011')).to eq('2011-AUG-25')
       expect(@report.send(:check_fy)).to eq('2011-AUG-25')
 
-      expect(@report.send(:write_cal_start, '2011')).to eq('2010-12-31')
-      expect(@report.send(:write_cal_end, '2011')).to eq('2011-12-30')
-      expect(@report.send(:write_pd_start, '04-OCT-96')).to eq('1996-OCT-03')
-      expect(@report.send(:write_pd_end, '04-OCT-97')).to eq('1997-OCT-03')
+      expect(@report.send(:write_cal_start, '2011')).to eq('2011-01-01')
+      expect(@report.send(:write_cal_end, '2011')).to eq('2011-12-31')
+      expect(@report.send(:write_pd_start, '04-OCT-96')).to eq('1996-OCT-04')
+      expect(@report.send(:write_pd_end, '04-OCT-97')).to eq('1997-OCT-04')
     end
     it 'sets the attribute for fund_acct with a fund_begin value' do
       @report.update_attributes(fund: nil)

--- a/spec/views/edi_error_reports/index.html.erb_spec.rb
+++ b/spec/views/edi_error_reports/index.html.erb_spec.rb
@@ -11,9 +11,7 @@ RSpec.describe 'edi_error_reports/index', type: :view do
       assert_select 'h1', text: 'EDIFACT invoice errors'.to_s
     end
     it 'should display an error line' do
-      assert_select 'td', text: '02/02/18 14:05'.to_s
-      assert_select 'td', text: /EDI_PROCESS_ORDER.do_inv_line_order:xcptn==stop_this_line ||===|| vendor==CASALI*/
-      assert_select 'td', text: /failed step==firm:verify_po on err==supplied PO# not in Unicorn:CAS6729454 edi_ckey:*/
+      assert_select 'td', text: '2018-02-02 14:05'.to_s
       assert_select 'td', text: 'notify'.to_s
     end
   end


### PR DESCRIPTION
The EdiErrorReport run date needs to be formatted in the same way as the original table in order to sort correctly within the datatable, and sorting has to be done explicitly so the data is pre-sorted before display in the datatable. 