### PR TITLE
Use locales oracle time

### DIFF
--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -98,7 +98,7 @@ class PackagesController < ApplicationController
   def list_transfer_logs
     # get vnd_runlog entries for the procedure just kicked off and related log entries
     @logs = VndRunlog.all.where('run_date >= ? AND LOWER(procedure_name) LIKE LOWER(?)',
-                                Time.now.getlocal.strftime('%Y-%m-%d %H:%M:%S'), 'VND%')
+                                l(Time.now.getlocal, format: :oracle), 'VND%')
   end
 
   private

--- a/app/models/circulation_statistics_report_log.rb
+++ b/app/models/circulation_statistics_report_log.rb
@@ -72,9 +72,9 @@ class CirculationStatisticsReportLog < ApplicationRecord
   def self.build_output_type(circ_stats)
     if circ_stats.range_type == 'barcodes'
       file_basename = File.basename(circ_stats.barcodes.original_filename, '.*')
-      { output_name: "#{file_basename}#{Time.zone.now.strftime('%y%m%d%H%M%S')}" }
+      { output_name: "#{file_basename}#{I18n.l(Time.now.getlocal, format: :timestamp)}" }
     else
-      { output_name: "circ_rpt#{Time.zone.now.strftime('%y%m%d%H%M%S')}" }
+      { output_name: "circ_rpt#{I18n.l(Time.now.getlocal, format: :timestamp)}" }
     end
   end
 end

--- a/app/views/change_current_locations/new.html.erb
+++ b/app/views/change_current_locations/new.html.erb
@@ -33,7 +33,7 @@
       <%= f.file_field 'item_ids', class: 'form-control-file' %>
     </div>
   </div>
-  <div class='form-group row', class: 'col-sm-2 form-control-label'>
+  <div class='form-group row col-sm-2 form-control-label'>
     <%= f.label 'Email (optional)', class: 'col-sm-2 form-control-label' %>
     <div class='col-sm-10'>
       <%= f.text_field 'email', class: 'form-control' %>
@@ -45,7 +45,7 @@
       <%= f.text_area 'comments', class: 'form-control' %>
     </div>
   </div>
-  <%= f.hidden_field :load_date, value: DateTime.now.midnight %>
+  <%= f.hidden_field :load_date, value:  l(Time.now.getlocal, format: :oracle) %>
   <%= f.hidden_field :user_name, value: current_user.user_id %>
   <%= f.hidden_field :action, value: 'UPDCURLOC' %>
   <%= f.hidden_field :priority, value: 3 %>

--- a/app/views/change_home_locations/new.html.erb
+++ b/app/views/change_home_locations/new.html.erb
@@ -39,7 +39,7 @@
       <%= f.file_field 'item_ids', class: 'form-control-file' %>
     </div>
   </div>
-  <div class='form-group row', class: 'col-sm-2 form-control-label'>
+  <div class='form-group row col-sm-2 form-control-label'>
     <%= f.label 'Email (optional)', class: 'col-sm-2 form-control-label' %>
     <div class='col-sm-10'>
       <%= f.text_field 'email', class: 'form-control' %>
@@ -51,7 +51,7 @@
       <%= f.text_area 'comments', class: 'form-control' %>
     </div>
   </div>
-  <%= f.hidden_field :load_date, value: DateTime.now.midnight %>
+  <%= f.hidden_field :load_date, value:  l(Time.now.getlocal, format: :oracle) %>
   <%= f.hidden_field :user_name, value: current_user.user_id %>
   <%= f.hidden_field :action, value: 'UPDHOMELOC' %>
   <%= f.hidden_field :priority, value: 3 %>

--- a/app/views/change_item_types/new.html.erb
+++ b/app/views/change_item_types/new.html.erb
@@ -27,7 +27,7 @@
       <%= f.file_field 'item_ids', class: 'form-control-file' %>
     </div>
   </div>
-  <div class='form-group row', class: 'col-sm-2 form-control-label'>
+  <div class='form-group row col-sm-2 form-control-label'>
     <%= f.label 'Email (optional)', class: 'col-sm-2 form-control-label' %>
     <div class='col-sm-10'>
       <%= f.text_field 'email', class: 'form-control' %>
@@ -39,7 +39,7 @@
       <%= f.text_area 'comments', class: 'form-control' %>
     </div>
   </div>
-  <%= f.hidden_field :load_date, value: DateTime.now.midnight %>
+  <%= f.hidden_field :load_date, value: l(Time.zone.now, format: :oracle) %>
   <%= f.hidden_field :user_name, value: current_user.user_id %>
   <%= f.hidden_field :action, value: 'UPDITEMTYPE' %>
   <%= f.hidden_field :priority, value: 3 %>

--- a/app/views/change_item_types/new.html.erb
+++ b/app/views/change_item_types/new.html.erb
@@ -39,7 +39,7 @@
       <%= f.text_area 'comments', class: 'form-control' %>
     </div>
   </div>
-  <%= f.hidden_field :load_date, value: l(Time.zone.now, format: :oracle) %>
+  <%= f.hidden_field :load_date, value: l(Time.now.getlocal, format: :oracle) %>
   <%= f.hidden_field :user_name, value: current_user.user_id %>
   <%= f.hidden_field :action, value: 'UPDITEMTYPE' %>
   <%= f.hidden_field :priority, value: 3 %>

--- a/app/views/digital_bookplates_batches/add_batch.html.erb
+++ b/app/views/digital_bookplates_batches/add_batch.html.erb
@@ -44,7 +44,7 @@
     </div>
   </div>
   <%= f.hidden_field :user_name, value: current_user.user_id %>
-  <%= f.hidden_field :submit_date, value: Time.now.getlocal.strftime('%Y-%m-%d %H:%M:%S') %>
+  <%= f.hidden_field :submit_date, value: l(Time.now.getlocal, format: :oracle) %>
   <%= f.hidden_field :batch_type, value: 'add' %>
   <div class="btn-group">
     <br />

--- a/app/views/digital_bookplates_batches/delete_batch.html.erb
+++ b/app/views/digital_bookplates_batches/delete_batch.html.erb
@@ -44,7 +44,7 @@
     </div>
   </div>
   <%= f.hidden_field :user_name, value: current_user.user_id %>
-  <%= f.hidden_field :submit_date, value: Time.now.getlocal.strftime('%Y-%m-%d %H:%M:%S') %>
+  <%= f.hidden_field :submit_date, value: l(Time.now.getlocal, format: :oracle) %>
   <%= f.hidden_field :batch_type, value: 'delete' %>
   <div class="btn-group">
     <br />

--- a/app/views/encumbrance_reports/new.html.erb
+++ b/app/views/encumbrance_reports/new.html.erb
@@ -32,8 +32,8 @@
   </div>
 
   <%= f.hidden_field :status, value: 'REQUEST' %>
-  <%= f.hidden_field :output_file, value: "enc_rpt#{Time.new.to_i}" %>
-  <%= f.hidden_field :date_request, value: l(Time.now.getlocal, format: :oracle) %>
+  <%= f.hidden_field :output_file, value: "enc_rpt#{l(Time.now.getlocal, format: :timestamp)}" %>
+  <%= f.hidden_field :date_request, value:  l(Time.now.getlocal, format: :oracle) %>
   <%= f.hidden_field :date_ran, value: nil %>
   <%= f.hidden_field :message, value: nil %>
 

--- a/app/views/encumbrance_reports/new.html.erb
+++ b/app/views/encumbrance_reports/new.html.erb
@@ -33,7 +33,7 @@
 
   <%= f.hidden_field :status, value: 'REQUEST' %>
   <%= f.hidden_field :output_file, value: "enc_rpt#{Time.new.to_i}" %>
-  <%= f.hidden_field :date_request, value: Time.now.getlocal.strftime('%Y-%m-%d %H:%M:%S') %>
+  <%= f.hidden_field :date_request, value: l(Time.now.getlocal, format: :oracle) %>
   <%= f.hidden_field :date_ran, value: nil %>
   <%= f.hidden_field :message, value: nil %>
 

--- a/app/views/endowed_funds_reports/new.html.erb
+++ b/app/views/endowed_funds_reports/new.html.erb
@@ -43,7 +43,7 @@
     </div>
   </div>
 
-  <%= f.hidden_field :ckeys_file, value: "endow#{Time.zone.now.strftime('%y%m%d%H%M%S%L%1N')}" %>
+  <%= f.hidden_field :ckeys_file, value: "endow#{l(Time.now.getlocal, format: :timestamp)}" %>
   <%= f.hidden_field :date_request, value: l(Time.now.getlocal, format: :oracle) %>
   <%= f.hidden_field :date_ran, value: nil %>
 

--- a/app/views/endowed_funds_reports/new.html.erb
+++ b/app/views/endowed_funds_reports/new.html.erb
@@ -44,7 +44,7 @@
   </div>
 
   <%= f.hidden_field :ckeys_file, value: "endow#{Time.zone.now.strftime('%y%m%d%H%M%S%L%1N')}" %>
-  <%= f.hidden_field :date_request, value: Time.now.getlocal.strftime('%Y-%m-%d %H:%M:%S') %>
+  <%= f.hidden_field :date_request, value: l(Time.now.getlocal, format: :oracle) %>
   <%= f.hidden_field :date_ran, value: nil %>
 
   <div class='pad'><%= f.submit 'Submit request', class: 'btn btn-md btn-default  btn-full' %></div><br/>

--- a/app/views/expenditure_reports/new.html.erb
+++ b/app/views/expenditure_reports/new.html.erb
@@ -22,7 +22,7 @@
   <%= f.hidden_field :output_file, value: "exp_rpt#{Time.new.to_i}" %>
   <%= f.hidden_field :message, value: nil %>
   <%= f.hidden_field :path_invlin_fund_keys, value: nil %>
-  <%= f.hidden_field :date_request, value: Time.now.getlocal.strftime('%Y-%m-%d %H:%M:%S') %>
+  <%= f.hidden_field :date_request, value: l(Time.now.getlocal, format: :oracle) %>
   <%= f.hidden_field :date_ran, value: nil %>
 
   <div class='pad'><%= f.submit 'Submit request', class: 'btn btn-md btn-default  btn-full' %></div><br/>

--- a/app/views/expenditures_with_circ_stats_reports/new.html.erb
+++ b/app/views/expenditures_with_circ_stats_reports/new.html.erb
@@ -38,7 +38,7 @@
 <%= f.hidden_field :status, value: 'REQUEST' %>
 <%= f.hidden_field :message, value: nil %>
 <%= f.hidden_field :output_file, value: "exp_rpt#{Time.new.to_i}" %>
-<%= f.hidden_field :date_request, value: Time.now.getlocal.strftime('%Y-%m-%d %H:%M:%S') %>
+<%= f.hidden_field :date_request, value: l(Time.now.getlocal, format: :oracle) %>
 <%= f.hidden_field :date_ran, value: nil %>
 
 <div class='pad'><%= f.submit 'Submit request', class: 'btn btn-md btn-default  btn-full' %></div><br/>

--- a/app/views/expenditures_with_circ_stats_reports/new.html.erb
+++ b/app/views/expenditures_with_circ_stats_reports/new.html.erb
@@ -37,7 +37,7 @@
 
 <%= f.hidden_field :status, value: 'REQUEST' %>
 <%= f.hidden_field :message, value: nil %>
-<%= f.hidden_field :output_file, value: "exp_rpt#{Time.new.to_i}" %>
+<%= f.hidden_field :output_file, value: "exp_rpt#{l(Time.now.getlocal, format: :timestamp)}" %>
 <%= f.hidden_field :date_request, value: l(Time.now.getlocal, format: :oracle) %>
 <%= f.hidden_field :date_ran, value: nil %>
 

--- a/app/views/transfer_items/new.html.erb
+++ b/app/views/transfer_items/new.html.erb
@@ -45,7 +45,7 @@
       <%= f.file_field 'item_ids', class: 'form-control-file' %>
     </div>
   </div>
-  <div class='form-group row', class: 'col-sm-2 form-control-label'>
+  <div class='form-group row col-sm-2 form-control-label'>
     <%= f.label 'Email (optional)', class: 'col-sm-2 form-control-label' %>
     <div class='col-sm-10'>
       <%= f.text_field 'email', class: 'form-control' %>
@@ -57,7 +57,7 @@
       <%= f.text_area 'comments', class: 'form-control' %>
     </div>
   </div>
-  <%= f.hidden_field :load_date, value: DateTime.now.midnight %>
+  <%= f.hidden_field :load_date, value:  l(Time.now.getlocal, format: :oracle) %>
   <%= f.hidden_field :user_name, value: current_user.user_id %>
   <%= f.hidden_field :action, value: 'TRANSFER' %>
   <%= f.hidden_field :priority, value: 3 %>

--- a/app/views/withdraw_items/new.html.erb
+++ b/app/views/withdraw_items/new.html.erb
@@ -21,7 +21,7 @@
       <%= f.file_field 'item_ids', class: 'form-control-file' %>
     </div>
   </div>
-  <div class='form-group row', class: 'col-sm-2 form-control-label'>
+  <div class='form-group row col-sm-2 form-control-label'>
     <%= f.label 'Email (optional)', class: 'col-sm-2 form-control-label' %>
     <div class='col-sm-10'>
       <%= f.text_field 'email', class: 'form-control' %>
@@ -33,7 +33,7 @@
       <%= f.text_area 'comments', class: 'form-control' %>
     </div>
   </div>
-  <%= f.hidden_field :load_date, value: DateTime.now.midnight %>
+  <%= f.hidden_field :load_date, value:  l(Time.now.getlocal, format: :oracle) %>
   <%= f.hidden_field :user_name, value: current_user.user_id %>
   <%= f.hidden_field :action, value: 'WITHDRAW' %>
   <%= f.hidden_field :priority, value: 3 %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,3 +63,6 @@ en:
         preprocess_put_script: 'Full path of preprocess put in AFS script'
         rpt_mail: 'Extra email addresses for reports'
         comments: 'Comments'
+  time:
+    formats:
+      oracle: '%Y-%m-%d %H:%M:%S'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,3 +66,4 @@ en:
   time:
     formats:
       oracle: '%Y-%m-%d %H:%M:%S'
+      timestamp: '%y%m%d%H%M%S%L%1N'

--- a/lib/tasks/webforms.rake
+++ b/lib/tasks/webforms.rake
@@ -6,7 +6,7 @@ namespace :webforms do
   task :transfer_items, %i[path_to_file current_lib new_lib new_homeloc new_curloc
                            new_itype email comments] => :environment do |_t, args|
     barcodes = IO.read(args[:path_to_file]).split("\n").uniq
-    @uni_updates_batch = UniUpdatesBatch.create(batch_date: Time.now.getlocal.strftime('%Y-%m-%d %H:%M:%S'),
+    @uni_updates_batch = UniUpdatesBatch.create(batch_date: l(Time.now.getlocal, format: :oracle),
                                                 user_name: 'batch',
                                                 user_email: args[:email],
                                                 action: 'TRANSFER',
@@ -33,7 +33,7 @@ namespace :webforms do
   desc 'Withdraw a batch'
   task :withdraw_items, %i[path_to_file current_lib email comments] => :environment do |_t, args|
     barcodes = IO.read(args[:path_to_file]).split("\n").uniq
-    @uni_updates_batch = UniUpdatesBatch.create(batch_date: Time.now.getlocal.strftime('%Y-%m-%d %H:%M:%S'),
+    @uni_updates_batch = UniUpdatesBatch.create(batch_date: l(Time.now.getlocal, format: :oracle),
                                                 user_name: 'batch',
                                                 user_email: args[:email],
                                                 action: 'WITHDRAW',
@@ -57,7 +57,7 @@ namespace :webforms do
   task :change_home_location, %i[path_to_file current_lib new_homeloc
                                  new_curloc new_itype email comments] => :environment do |_t, args|
     barcodes = IO.read(args[:path_to_file]).split("\n").uniq
-    @uni_updates_batch = UniUpdatesBatch.create(batch_date: Time.now.getlocal.strftime('%Y-%m-%d %H:%M:%S'),
+    @uni_updates_batch = UniUpdatesBatch.create(batch_date: l(Time.now.getlocal, format: :oracle),
                                                 user_name: 'batch',
                                                 user_email: args[:email],
                                                 action: 'UPDHOMELOC',
@@ -84,7 +84,7 @@ namespace :webforms do
   task :change_current_location, %i[path_to_file current_lib
                                     new_curloc email comments] => :environment do |_t, args|
     barcodes = IO.read(args[:path_to_file]).split("\n").uniq
-    @uni_updates_batch = UniUpdatesBatch.create(batch_date: Time.now.getlocal.strftime('%Y-%m-%d %H:%M:%S'),
+    @uni_updates_batch = UniUpdatesBatch.create(batch_date: l(Time.now.getlocal, format: :oracle),
                                                 user_name: 'batch',
                                                 user_email: args[:email],
                                                 action: 'UPDCURLOC',
@@ -109,7 +109,7 @@ namespace :webforms do
   task :change_item_type, %i[path_to_file current_lib new_itype
                              email comments] => :environment do |_t, args|
     barcodes = IO.read(args[:path_to_file]).split("\n").uniq
-    @uni_updates_batch = UniUpdatesBatch.create(batch_date: Time.now.getlocal.strftime('%Y-%m-%d %H:%M:%S'),
+    @uni_updates_batch = UniUpdatesBatch.create(batch_date: l(Time.now.getlocal, format: :oracle),
                                                 user_name: 'batch',
                                                 user_email: args[:email],
                                                 action: 'UPDITEMTYPE',

--- a/lib/tasks/webforms.rake
+++ b/lib/tasks/webforms.rake
@@ -6,7 +6,7 @@ namespace :webforms do
   task :transfer_items, %i[path_to_file current_lib new_lib new_homeloc new_curloc
                            new_itype email comments] => :environment do |_t, args|
     barcodes = IO.read(args[:path_to_file]).split("\n").uniq
-    @uni_updates_batch = UniUpdatesBatch.create(batch_date: l(Time.now.getlocal, format: :oracle),
+    @uni_updates_batch = UniUpdatesBatch.create(batch_date: I18n.l(Time.now.getlocal, format: :oracle),
                                                 user_name: 'batch',
                                                 user_email: args[:email],
                                                 action: 'TRANSFER',
@@ -33,7 +33,7 @@ namespace :webforms do
   desc 'Withdraw a batch'
   task :withdraw_items, %i[path_to_file current_lib email comments] => :environment do |_t, args|
     barcodes = IO.read(args[:path_to_file]).split("\n").uniq
-    @uni_updates_batch = UniUpdatesBatch.create(batch_date: l(Time.now.getlocal, format: :oracle),
+    @uni_updates_batch = UniUpdatesBatch.create(batch_date: I18n.l(Time.now.getlocal, format: :oracle),
                                                 user_name: 'batch',
                                                 user_email: args[:email],
                                                 action: 'WITHDRAW',
@@ -57,7 +57,7 @@ namespace :webforms do
   task :change_home_location, %i[path_to_file current_lib new_homeloc
                                  new_curloc new_itype email comments] => :environment do |_t, args|
     barcodes = IO.read(args[:path_to_file]).split("\n").uniq
-    @uni_updates_batch = UniUpdatesBatch.create(batch_date: l(Time.now.getlocal, format: :oracle),
+    @uni_updates_batch = UniUpdatesBatch.create(batch_date: I18n.l(Time.now.getlocal, format: :oracle),
                                                 user_name: 'batch',
                                                 user_email: args[:email],
                                                 action: 'UPDHOMELOC',
@@ -84,7 +84,7 @@ namespace :webforms do
   task :change_current_location, %i[path_to_file current_lib
                                     new_curloc email comments] => :environment do |_t, args|
     barcodes = IO.read(args[:path_to_file]).split("\n").uniq
-    @uni_updates_batch = UniUpdatesBatch.create(batch_date: l(Time.now.getlocal, format: :oracle),
+    @uni_updates_batch = UniUpdatesBatch.create(batch_date: I18n.l(Time.now.getlocal, format: :oracle),
                                                 user_name: 'batch',
                                                 user_email: args[:email],
                                                 action: 'UPDCURLOC',
@@ -109,7 +109,7 @@ namespace :webforms do
   task :change_item_type, %i[path_to_file current_lib new_itype
                              email comments] => :environment do |_t, args|
     barcodes = IO.read(args[:path_to_file]).split("\n").uniq
-    @uni_updates_batch = UniUpdatesBatch.create(batch_date: l(Time.now.getlocal, format: :oracle),
+    @uni_updates_batch = UniUpdatesBatch.create(batch_date: I18n.l(Time.now.getlocal, format: :oracle),
                                                 user_name: 'batch',
                                                 user_email: args[:email],
                                                 action: 'UPDITEMTYPE',

--- a/spec/features/encumbrance_reports_spec.rb
+++ b/spec/features/encumbrance_reports_spec.rb
@@ -7,6 +7,6 @@ describe 'Encumbrance Reports Page', type: :feature do
 
   it 'renders the hidden field for date_request' do
     attribute = page.find('#encumbrance_report_date_request', visible: false).value
-    expect(attribute).to eq Time.now.getlocal.strftime('%Y-%m-%d %H:%M:%S')
+    expect(attribute).to eq I18n.l(Time.now.getlocal, format: :oracle)
   end
 end

--- a/spec/features/endowed_funds_reports_spec.rb
+++ b/spec/features/endowed_funds_reports_spec.rb
@@ -7,6 +7,6 @@ describe 'Endowed Funds Reports Page', type: :feature do
 
   it 'renders the hidden field for date_request' do
     attribute = page.find('#endowed_funds_report_date_request', visible: false).value
-    expect(attribute).to eq Time.now.getlocal.strftime('%Y-%m-%d %H:%M:%S')
+    expect(attribute).to eq I18n.l(Time.now.getlocal, format: :oracle)
   end
 end

--- a/spec/features/expenditure_reports_spec.rb
+++ b/spec/features/expenditure_reports_spec.rb
@@ -7,6 +7,6 @@ describe 'Expenditure Reports Page', type: :feature do
 
   it 'renders the hidden field for date_request' do
     attribute = page.find('#expenditure_report_date_request', visible: false).value
-    expect(attribute).to match Time.now.getlocal.strftime('%Y-%m-%d %H:%M')
+    expect(attribute).to eq I18n.l(Time.now.getlocal, format: :oracle)
   end
 end

--- a/spec/features/expenditures_with_circ_stats_reports_spec.rb
+++ b/spec/features/expenditures_with_circ_stats_reports_spec.rb
@@ -7,6 +7,6 @@ describe 'Expenditures With Circ Stats Reports Page', type: :feature do
 
   it 'renders the hidden field for date_request' do
     attribute = page.find('#expenditures_with_circ_stats_report_date_request', visible: false).value
-    expect(attribute).to eq Time.now.getlocal.strftime('%Y-%m-%d %H:%M:%S')
+    expect(attribute).to eq I18n.l(Time.now.getlocal, format: :oracle)
   end
 end


### PR DESCRIPTION
We define different time formats in many places. In order to keep the most complex ones consistent, let's use the Rails I18n functionality to define the oracle and timestamp time formats globally for the application.