### PR TITLE
Truncate time format for test matchers

### DIFF
--- a/spec/features/encumbrance_reports_spec.rb
+++ b/spec/features/encumbrance_reports_spec.rb
@@ -7,6 +7,8 @@ describe 'Encumbrance Reports Page', type: :feature do
 
   it 'renders the hidden field for date_request' do
     attribute = page.find('#encumbrance_report_date_request', visible: false).value
-    expect(attribute).to eq I18n.l(Time.now.getlocal, format: :oracle)
+    time = Time.parse(attribute)
+    now = Time.parse(I18n.l(Time.now.getlocal, format: :oracle))
+    expect(time.strftime('%F %R')).to eq now.strftime('%F %R')
   end
 end

--- a/spec/features/endowed_funds_reports_spec.rb
+++ b/spec/features/endowed_funds_reports_spec.rb
@@ -7,6 +7,8 @@ describe 'Endowed Funds Reports Page', type: :feature do
 
   it 'renders the hidden field for date_request' do
     attribute = page.find('#endowed_funds_report_date_request', visible: false).value
-    expect(attribute).to eq I18n.l(Time.now.getlocal, format: :oracle)
+    time = Time.parse(attribute)
+    now = Time.parse(I18n.l(Time.now.getlocal, format: :oracle))
+    expect(time.strftime('%F %R')).to eq now.strftime('%F %R')
   end
 end

--- a/spec/features/expenditure_reports_spec.rb
+++ b/spec/features/expenditure_reports_spec.rb
@@ -7,6 +7,8 @@ describe 'Expenditure Reports Page', type: :feature do
 
   it 'renders the hidden field for date_request' do
     attribute = page.find('#expenditure_report_date_request', visible: false).value
-    expect(attribute).to eq I18n.l(Time.now.getlocal, format: :oracle)
+    time = Time.parse(attribute)
+    now = Time.parse(I18n.l(Time.now.getlocal, format: :oracle))
+    expect(time.strftime('%F %R')).to eq now.strftime('%F %R')
   end
 end

--- a/spec/features/expenditures_with_circ_stats_reports_spec.rb
+++ b/spec/features/expenditures_with_circ_stats_reports_spec.rb
@@ -7,6 +7,8 @@ describe 'Expenditures With Circ Stats Reports Page', type: :feature do
 
   it 'renders the hidden field for date_request' do
     attribute = page.find('#expenditures_with_circ_stats_report_date_request', visible: false).value
-    expect(attribute).to eq I18n.l(Time.now.getlocal, format: :oracle)
+    time = Time.parse(attribute)
+    now = Time.parse(I18n.l(Time.now.getlocal, format: :oracle))
+    expect(time.strftime('%F %R')).to eq now.strftime('%F %R')
   end
 end


### PR DESCRIPTION
So they do not have to be within the same second when tests run. This will fix intermittently failing tests that depend on the parsing of dates.