### PR TITLE
remove unnecessary alias action

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -14,7 +14,6 @@ class Ability
     assign_batch_permission if /A|Y/.match?(current_user.unicorn_updates)
     alias_action :queue, :completed, :recent, to: :read
     alias_action :menu, to: :read
-    alias_action :activate, :deactivate, to: :manage
   end
 
   def assign_basic_permission


### PR DESCRIPTION
See https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities#the-can-method

e.g.
```
can :manage, Article  # user can perform any action on the article
```

