### PR TITLE
Break up long line

### DIFF
--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -36,7 +36,12 @@ def admin_permissions
 end
 
 def only_authorized_permissions
-  perms = staff_specified_permissions + staff_create_permissions + staff_read_permissions + staff_manage_permissions + admin_permissions # rubocop:disable Metrics/LineLength
+  perms = staff_specified_permissions \
+  + staff_create_permissions \
+  + staff_read_permissions \
+  + staff_manage_permissions \
+  + admin_permissions
+
   perms -= [BatchRecordUpdate]
   perms
 end


### PR DESCRIPTION
Rubocop was getting `spec/models/ability_spec.rb: Metrics/LineLength has the wrong namespace - should be Layout`