### PR TITLE
Mgt rpts validation

### DIFF
--- a/app/models/circulation_statistics_report.rb
+++ b/app/models/circulation_statistics_report.rb
@@ -11,6 +11,7 @@ class CirculationStatisticsReport
                 :col_header2, :col_header3, :col_header4, :col_header5,
                 :blank_col_array, :lib_loc_array, :user_id
 
+  validates :lib_array, length: { minimum: 2, message: 'Select at least one library' }, unless: :barcode_range_type?
   validates :barcodes, presence: { is: true, message: 'Upload a file of barcodes' }, if: :barcode_range_type?
   validates :email, format: { with: Rails.configuration.email_pattern,
                               message: 'Email address is missing or not in a correct format' }
@@ -28,7 +29,6 @@ class CirculationStatisticsReport
                          numericality: { only_integer: true, message: 'Bibfield must be a 3-digit number' },
                          exclusion: { in: %w[008], message: 'Bibfield cannot be 008' },
                          allow_blank: true
-  validate :library_present
   validate :lc_call_lo, if: :lc_range_type?
   validate :lc_call_hi, if: :lc_range_type?
   validate :classic_call_lo_and_hi, if: :classic_range_type?
@@ -58,11 +58,6 @@ class CirculationStatisticsReport
 
   def call_regex
     /^[A-Z]{1,2}$|^[A-Z]\#$/
-  end
-
-  def library_present
-    message = 'Select at least one library'
-    errors.add(:base, message) unless lib_array.any?(&:present?) || barcode_range_type?
   end
 
   def lc_call_lo

--- a/app/models/circulation_statistics_report.rb
+++ b/app/models/circulation_statistics_report.rb
@@ -7,9 +7,9 @@ class CirculationStatisticsReport
   attr_accessor :email, :lib_array, :source, :range_type, :call_lo, :call_hi,
                 :call_alpha, :barcodes, :format_array, :exclude_inactive, :min_yr,
                 :max_yr, :exclude_bad_yr, :include_inhouse, :no_qtrly, :ckey_url,
-                :tag_field, :tag_field2, :tags_url, :link_type, :col_header1,
-                :col_header2, :col_header3, :col_header4, :col_header5,
-                :blank_col_array, :lib_loc_array, :user_id
+                :tag_field, :tag_field2, :tag_field3, :tag_field4, :tags_url,
+                :link_type, :col_header1, :col_header2, :col_header3, :col_header4,
+                :col_header5, :blank_col_array, :lib_loc_array, :user_id
 
   validates :lib_array, length: { minimum: 2, message: 'Select at least one library' }, unless: :barcode_range_type?
   validates :barcodes, presence: { is: true, message: 'Upload a file of barcodes' }, if: :barcode_range_type?
@@ -21,14 +21,14 @@ class CirculationStatisticsReport
   validates :max_yr, length: { is: 4, message: 'Year length must be four digits' },
                      numericality: { only_integer: true },
                      allow_blank: true
-  validates :tag_field, length: { is: 3, message: 'Bibfield number must be 3 digits' },
-                        numericality: { only_integer: true, message: 'Bibfield must be a 3-digit number' },
-                        exclusion: { in: %w[008], message: 'Bibfield cannot be 008' },
-                        allow_blank: true
-  validates :tag_field2, length: { is: 3, message: 'Bibfield number must be 3 digits' },
-                         numericality: { only_integer: true, message: 'Bibfield must be a 3-digit number' },
-                         exclusion: { in: %w[008], message: 'Bibfield cannot be 008' },
-                         allow_blank: true
+  validates :tag_field, :tag_field2, :tag_field3, :tag_field4, length: { is: 3,
+                                                                         message: 'Bibfield number must be 3 digits' },
+                                                               numericality: { only_integer: true,
+                                                                               message:
+                                                                                 'Bibfield must be a 3-digit number' },
+                                                               exclusion: { in: %w[008],
+                                                                            message: 'Bibfield cannot be 008' },
+                                                               allow_blank: true
   validate :lc_call_lo, if: :lc_range_type?
   validate :lc_call_hi, if: :lc_range_type?
   validate :classic_call_lo_and_hi, if: :classic_range_type?

--- a/app/models/circulation_statistics_report.rb
+++ b/app/models/circulation_statistics_report.rb
@@ -7,22 +7,32 @@ class CirculationStatisticsReport
   attr_accessor :email, :lib_array, :source, :range_type, :call_lo, :call_hi,
                 :call_alpha, :barcodes, :format_array, :exclude_inactive, :min_yr,
                 :max_yr, :exclude_bad_yr, :include_inhouse, :no_qtrly, :ckey_url,
-                :tag_field, :tag_field2, :tag_field3, :tag_field4, :tags_url,
-                :link_type, :col_header1, :col_header2, :col_header3, :col_header4,
-                :col_header5, :blank_col_array, :lib_loc_array, :user_id
+                :tag_field, :tag_field2, :tags_url, :link_type, :col_header1,
+                :col_header2, :col_header3, :col_header4, :col_header5,
+                :blank_col_array, :lib_loc_array, :user_id
 
-  validates :email, :lib_array, presence: true
-  validates :barcodes, presence: true, if: :barcode_range_type?
-  validates :lib_array, length: { minimum: 2, message: "can't be empty" }, if: :not_barcode_range_type?
-  validates :min_yr, length: { is: 4 }, numericality: { only_integer: true }, allow_blank: true
-  validates :max_yr, length: { is: 4 }, numericality: { only_integer: true }, allow_blank: true
-  validates :tag_field, :tag_field2, :tag_field3, :tag_field4, length: { is: 3 }, numericality: { only_integer: true },
-                                                               exclusion: { in: %w[008] }, allow_blank: true
+  validates :barcodes, presence: { is: true, message: 'Upload a file of barcodes' }, if: :barcode_range_type?
+  validates :email, format: { with: Rails.configuration.email_pattern,
+                              message: 'Email address is missing or not in a correct format' }
+  validates :min_yr, length: { is: 4, message: 'Year length must be four digits' },
+                     numericality: { only_integer: true },
+                     allow_blank: true
+  validates :max_yr, length: { is: 4, message: 'Year length must be four digits' },
+                     numericality: { only_integer: true },
+                     allow_blank: true
+  validates :tag_field, length: { is: 3, message: 'Bibfield number must be 3 digits' },
+                        numericality: { only_integer: true, message: 'Bibfield must be a 3-digit number' },
+                        exclusion: { in: %w[008], message: 'Bibfield cannot be 008' },
+                        allow_blank: true
+  validates :tag_field2, length: { is: 3, message: 'Bibfield number must be 3 digits' },
+                         numericality: { only_integer: true, message: 'Bibfield must be a 3-digit number' },
+                         exclusion: { in: %w[008], message: 'Bibfield cannot be 008' },
+                         allow_blank: true
+  validate :library_present
   validate :lc_call_lo, if: :lc_range_type?
   validate :lc_call_hi, if: :lc_range_type?
   validate :classic_call_lo_and_hi, if: :classic_range_type?
   validate :classic_call_alpha, if: :classic_range_type?
-  validates :email, format: { with: Rails.configuration.email_pattern }, allow_blank: true
 
   before_validation :upcase_call_numbers
 
@@ -46,12 +56,13 @@ class CirculationStatisticsReport
     range_type == 'classic'
   end
 
-  def not_barcode_range_type?
-    range_type != 'barcodes'
-  end
-
   def call_regex
     /^[A-Z]{1,2}$|^[A-Z]\#$/
+  end
+
+  def library_present
+    message = 'Select at least one library'
+    errors.add(:base, message) unless lib_array.any?(&:present?) || barcode_range_type?
   end
 
   def lc_call_lo

--- a/app/models/encumbrance_report.rb
+++ b/app/models/encumbrance_report.rb
@@ -49,7 +49,7 @@ class EncumbranceReport < ApplicationRecord
   end
 
   def fund_selection_present
-    message = 'Select either a single Fund ID/PTA or a fund that begins with an ID/PTA number'
+    message = 'Select a single Fund ID/PTA, a fund that begins with an ID/PTA number, or all SUL funds'
     errors.add(:base, message) unless fund.present? || fund_begin.present?
   end
 end

--- a/app/models/encumbrance_report.rb
+++ b/app/models/encumbrance_report.rb
@@ -5,10 +5,8 @@ class EncumbranceReport < ApplicationRecord
   attr_accessor :fund_select, :show_dates, :fund, :fund_begin, :email, :status,
                 :date_ran, :date_request, :output_file, :fund_acct
 
-  validates :email, :status, :date_request, :output_file, presence: true
-  validates :email, format: { with: Rails.configuration.email_pattern }, allow_blank: true
-  validates :fund, presence: true, if: :blank_fund_begin?
-  validates :fund_begin, presence: true, if: :blank_fund?
+  validate :email_format
+  validate :fund_selection_present
 
   before_save :set_fund, :write_dates, :set_email, :set_status, :set_output_file
 
@@ -20,14 +18,6 @@ class EncumbranceReport < ApplicationRecord
   end
 
   private
-
-  def blank_fund_begin?
-    fund_begin.blank?
-  end
-
-  def blank_fund?
-    fund.blank?
-  end
 
   def set_fund
     if fund.present?
@@ -51,5 +41,15 @@ class EncumbranceReport < ApplicationRecord
 
   def set_output_file
     self[:output_file] = output_file
+  end
+
+  def email_format
+    message = 'Email address is missing or not in a correct format'
+    errors.add(:base, message) unless email.match(Rails.configuration.email_pattern)
+  end
+
+  def fund_selection_present
+    message = 'Select either a single Fund ID/PTA or a fund that begins with an ID/PTA number'
+    errors.add(:base, message) unless fund.present? || fund_begin.present?
   end
 end

--- a/app/models/expenditure_report.rb
+++ b/app/models/expenditure_report.rb
@@ -32,12 +32,12 @@ class ExpenditureReport < ApplicationRecord
 
   def type_of_date_present?
     case date_type
-      when 'calendar'
-        cal_start.present?
-      when 'fiscal'
-        fy_start.present?
-      when 'paydate'
-        pd_start.present?
+    when 'calendar'
+      cal_start.present?
+    when 'fiscal'
+      fy_start.present?
+    when 'paydate'
+      pd_start.present?
     end
   end
 

--- a/app/models/expenditures_with_circ_stats_report.rb
+++ b/app/models/expenditures_with_circ_stats_report.rb
@@ -7,12 +7,10 @@ class ExpendituresWithCircStatsReport < ApplicationRecord
                 :fy_start, :fy_end, :cal_start, :cal_end, :pd_start, :pd_end,
                 :lib_array, :libraries, :format_array, :formats
 
-  validates :fund, presence: true, if: :blank_fund_begin?
-  validates :fund_begin, presence: true, if: :blank_fund?
-  validates :lib_array, presence: true
-  validates :format_array, presence: true
   validates :date_type, inclusion: %w[fiscal calendar paydate]
   validates :start_date_present?, inclusion: { in: [true], message: 'Please choose a start date for the report.' }
+  validate :email_format
+  validate :fund_selection_present
 
   before_save :set_fund, :write_lib, :write_fmt, :check_dates
 
@@ -45,5 +43,15 @@ class ExpendituresWithCircStatsReport < ApplicationRecord
     when 'paydate'
       pd_start.present?
     end
+  end
+
+  def email_format
+    message = 'Email address is missing or not in a correct format'
+    errors.add(:base, message) unless email.match(Rails.configuration.email_pattern)
+  end
+
+  def fund_selection_present
+    message = 'Select either a single Fund ID/PTA or a fund that begins with an ID/PTA number'
+    errors.add(:base, message) unless fund.present? || fund_begin.present?
   end
 end

--- a/app/views/circulation_statistics_reports/new.html.erb
+++ b/app/views/circulation_statistics_reports/new.html.erb
@@ -6,8 +6,10 @@
   <% if @circulation_statistics_report.errors.any? %>
     <div id="error-explanation">
       <ul>
-        <% @circulation_statistics_report.errors.full_messages.each do |msg| %>
-          <li><%= msg %></li>
+        <% @circulation_statistics_report.errors.messages.values.each do |msg| %>
+            <%msg.each do  |m| %>
+                <li><%= m %></li>
+            <%end %>
         <% end %>
       </ul>
     </div>

--- a/app/views/shelf_selection_reports/new.html.erb
+++ b/app/views/shelf_selection_reports/new.html.erb
@@ -192,9 +192,9 @@
   </div>
   <P>
   <div class='form-group row'>
-    <%= f.label :subj_name, 'Name of this report\'s selection criteria. Leave blank to not use.', class: 'col-sm-4 form-control-label' %>
-    <div class='col-sm-8'>
-      <%= f.text_field :subj_name, class: 'form-control' %>
+    <%= f.label :subj_name, 'Name of this report\'s selection criteria. Leave blank to not use.', class: 'col-sm-10 form-control-label' %>
+    <div class='col-sm-10'>
+      <%= f.text_field :subj_name, maxlength: 80, class: 'form-control' %>
       <em>The control allows entering up to 80 characters.</em>
     </div>
   </div>

--- a/spec/controllers/circulation_statistics_reports_controller_spec.rb
+++ b/spec/controllers/circulation_statistics_reports_controller_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe CirculationStatisticsReportsController, type: :controller do
       format_array: ['', 'MARC'],
       call_lo: 'L' }
   end
+
   let(:invalid_attributes) { valid_attributes.update(lib_array: nil) }
 
   describe 'get#new' do

--- a/spec/controllers/encumbrance_reports_controller_spec.rb
+++ b/spec/controllers/encumbrance_reports_controller_spec.rb
@@ -12,16 +12,16 @@ RSpec.describe EncumbranceReportsController, type: :controller do
   describe 'post#create' do
     it 'returns ok when saving encumbrance report' do
       stub_current_user(FactoryBot.create(:authorized_user))
-      post :create, params: { encumbrance_report: { email: 'someone@some.one',
-                                                    fund: %w[1008930-1-HAGOY],
-                                                    fundcyc_cycle: '2016' } }
+      post :create, params: { encumbrance_report: { email: 'someone@some.one', fund: %w[1008930-1-HAGOY],
+                                                    fundcyc_cycle: '2016', status: 'REQUEST', output_file: 'enc_rpt123',
+                                                    date_request: '2010-01-01 14:22:33' } }
 
-      expect(response).to have_http_status(:ok)
+      expect(response).to redirect_to root_path
     end
 
     it 'renders new template with an invalid object' do
       stub_current_user(FactoryBot.create(:authorized_user))
-      post :create, params: { encumbrance_report: { fund: '' } }
+      post :create, params: { encumbrance_report: { email: 'someone@some.one', fund: '' } }
       expect(response).to render_template('new')
     end
   end

--- a/spec/controllers/shelf_selection_reports_controller_spec.rb
+++ b/spec/controllers/shelf_selection_reports_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ShelfSelectionReportsController, type: :controller do
     end
 
     it 'renders the new action when params are invalid' do
-      post :create, params: { shelf_selection_report: { email: '' } }
+      post :create, params: { shelf_selection_report: { email: '', loc_array: 'ALL' } }
       expect(response).to render_template('new')
     end
   end

--- a/spec/factories/endowed_funds_report.rb
+++ b/spec/factories/endowed_funds_report.rb
@@ -15,14 +15,14 @@ FactoryBot.define do
     ta_taxtype_flag { '' }
     ta_vend_inv_date { '14-JUL-16' }
     ta_vend_inv_num   { '' }
-    ti_inv_lib        { '' }
+    ti_inv_lib        { 'SUL' }
     ti_inv_line_note  { '' }
     ti_inv_line_num   { '' }
     ti_inv_line_total_us { 100 }
     ti_unicorn_inv_num  { '' }
     ti_inv_line_type    { '' }
     ti_inv_line_total_vendor { 100 }
-    ti_fiscal_cycle     { '' }
+    ti_fiscal_cycle     { '2010' }
     ti_vendor_alpha_id  { '' }
     to_order_id         { '' }
     to_order_line_num { 1 }
@@ -34,7 +34,7 @@ FactoryBot.define do
     to_order_line_seg_type { '' }
     ts_date_mailed { '14-JUL-16' }
     ol_selector { '' }
-    ol_cat_key  { '1234567' }
+    ol_cat_key  { '' }
     ol_call_seq { '' }
     ds_hold_code { '' }
     d2_hldc_lib { '' }

--- a/spec/models/encumbrance_report_spec.rb
+++ b/spec/models/encumbrance_report_spec.rb
@@ -22,49 +22,18 @@ RSpec.describe EncumbranceReport, type: :model do
 
   describe 'validations' do
     before do
-      @report = described_class.new(email: nil,
-                                    fund_begin: nil,
-                                    fund: nil,
-                                    status: nil,
-                                    output_file: nil,
-                                    date_request: nil)
-      @report.valid?
+      @report = FactoryBot.build(:encumbrance_report,
+                                 email: '', fund_begin: nil, fund: nil)
+      @report.validate
     end
 
     it 'validates the presence of an email address' do
-      expect(@report.errors.messages[:email]).to include "can't be blank"
-    end
-
-    it 'validates the presence of a fund_begin' do
-      expect(@report.errors.messages[:fund_begin]).to include "can't be blank"
+      expect(@report.errors.messages[:base]).to include 'Email address is missing or not in a correct format'
     end
 
     it 'validates the presence of a fund' do
-      expect(@report.errors.messages[:fund]).to include "can't be blank"
-    end
-
-    it 'validates the correct form of an email address' do
-      @report = described_class.new(email: 'test@testtest.com')
-      @report.valid?
-      expect(@report.errors.messages[:email]).not_to include "can't be blank"
-    end
-
-    it 'validates the incorrect form of an email address' do
-      @report = described_class.new(email: 'test@test@test.com')
-      @report.valid?
-      expect(@report.errors.messages[:email]).to include 'is invalid'
-    end
-
-    it 'validates presence of request_date' do
-      expect(@report.errors.messages[:date_request]).to include "can't be blank"
-    end
-
-    it 'validates presence of status' do
-      expect(@report.errors.messages[:status]).to include "can't be blank"
-    end
-
-    it 'validates presence of output_file' do
-      expect(@report.errors.messages[:output_file]).to include "can't be blank"
+      expect(@report.errors.messages[:base]).to include \
+        'Select a single Fund ID/PTA, a fund that begins with an ID/PTA number, or all SUL funds'
     end
   end
 end

--- a/spec/models/expenditure_report_spec.rb
+++ b/spec/models/expenditure_report_spec.rb
@@ -80,40 +80,22 @@ RSpec.describe ExpenditureReport, type: :model do
 
   describe 'validations' do
     before do
-      @report = described_class.new(date_type: nil, email: nil, fund_begin: nil, fund: nil, cal_start: nil)
-      @report.valid?
-    end
-
-    it 'validates the inclusion of a date_type' do
-      expect(@report.errors.messages[:date_type]).to include 'is not included in the list'
+      @report = FactoryBot.build(:expenditure_report,
+                                 email: '', date_type: nil, fund_begin: nil, fund: nil, cal_start: nil)
+      @report.validate
     end
 
     it 'validates the presence of an email address' do
-      expect(@report.errors.messages[:email]).to include "can't be blank"
-    end
-
-    it 'validates the presence of a fund_begin' do
-      expect(@report.errors.messages[:fund_begin]).to include "can't be blank"
+      expect(@report.errors.messages[:base]).to include 'Email address is missing or not in a correct format'
     end
 
     it 'validates the presence of a fund' do
-      expect(@report.errors.messages[:fund]).to include "can't be blank"
+      expect(@report.errors.messages[:base]).to include \
+        'Select a single Fund ID/PTA, a fund that begins with an ID/PTA number, or all SUL funds'
     end
 
-    it 'validates the presence of a start date' do
-      expect(@report.errors.messages[:start_date_present?]).to include 'Please choose a start date for the report.'
-    end
-
-    it 'validates the correct form of an email address' do
-      @report = described_class.new(email: 'test@testtest.com')
-      @report.valid?
-      expect(@report.errors.messages[:email]).not_to include "can't be blank"
-    end
-
-    it 'validates the incorrect form of an email address' do
-      @report = described_class.new(email: 'test@test@test.com')
-      @report.valid?
-      expect(@report.errors.messages[:email]).to include 'is invalid'
+    it 'validates the presence of a date' do
+      expect(@report.errors.messages[:base]).to include 'Choose a start date for fiscal, calendar, or paid date'
     end
   end
 end

--- a/spec/models/expenditures_with_circ_stats_report_spec.rb
+++ b/spec/models/expenditures_with_circ_stats_report_spec.rb
@@ -153,33 +153,19 @@ RSpec.describe ExpendituresWithCircStatsReport, type: :model do
 
   describe 'validations' do
     before do
-      @report = described_class.new(date_type: nil, format_array: nil, lib_array: nil,
-                                    fund_begin: nil, fund: nil, cal_start: nil)
-      @report.valid?
+      @report = FactoryBot.build(:expenditures_with_circ_stats_report,
+                                 date_type: nil, fund_begin: nil, fund: nil, cal_start: nil)
+
+      @report.validate
     end
 
-    it 'validates the inclusion of a date_type' do
-      expect(@report.errors.messages[:date_type]).to include 'is not included in the list'
-    end
-
-    it 'validates the presence of a fund_begin' do
-      expect(@report.errors.messages[:fund_begin]).to include "can't be blank"
+    it 'validates the inclusion of a start date' do
+      expect(@report.errors.messages[:base]).to include 'Choose a start date for fiscal, calendar, or paid date'
     end
 
     it 'validates the presence of a fund' do
-      expect(@report.errors.messages[:fund]).to include "can't be blank"
-    end
-
-    it 'validated the presence of a format_array' do
-      expect(@report.errors.messages[:format_array]).to include "can't be blank"
-    end
-
-    it 'validated the presence of a lib_array' do
-      expect(@report.errors.messages[:lib_array]).to include "can't be blank"
-    end
-
-    it 'validates the presence of a start date' do
-      expect(@report.errors.messages[:start_date_present?]).to include 'Please choose a start date for the report.'
+      expect(@report.errors.messages[:base]).to include \
+        'Select a single Fund ID/PTA, a fund that begins with an ID/PTA number, or all SUL funds'
     end
   end
 end


### PR DESCRIPTION
Fixes #703 

Also refactors Endowed Funds Report by moving methods that should be in the model and streamlines the tests the to only test what is necessary. It is not possible to test the sql queries that require oracle date formats without using special testing methods in the model, so we are only testing the fiscal year methods, not the calendar year or paid dates.