### PR TITLE
Adds dependabot config to ignore some updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,9 @@
+version: 1
+update_configs:
+  - package_manager: "ruby:bundler"
+    directory: "/"
+    update_schedule: "weekly"
+    ignored_updates:
+      - match:
+          dependency_name: "rails"
+          dependency_name: "activerecord-oracle_enhanced-adapter"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -6,4 +6,5 @@ update_configs:
     ignored_updates:
       - match:
           dependency_name: "rails"
+      - match:
           dependency_name: "activerecord-oracle_enhanced-adapter"


### PR DESCRIPTION
We are not ready to update rails to version 6. This will tell dependabot to ignore rails and activerecord-oracle updates.