### PR TITLE
Remove sul-cdn call for icons

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,6 @@
 
   <title>LibsysWebforms</title>
   <link href="https://www.stanford.edu/su-identity/css/su-identity.css" rel="stylesheet">
-  <link rel="stylesheet" href="https://sul-cdn.stanford.edu/sul_styles/0.5.0/sul-icons.min.css">
   <%= favicon_link_tag 'favicon.ico' %>
   <%= stylesheet_link_tag 'application', media: 'all' %>
   <%= stylesheet_link_tag 'https://cdn.datatables.net/v/dt/dt-1.10.16/datatables.min.css' %>

--- a/app/views/layouts/ssds.html.erb
+++ b/app/views/layouts/ssds.html.erb
@@ -8,7 +8,6 @@
 
   <title>SSRC dataset request</title>
   <link href="https://www.stanford.edu/su-identity/css/su-identity.css" rel="stylesheet">
-  <link rel="stylesheet" href="https://sul-cdn.stanford.edu/sul_styles/0.5.0/sul-icons.min.css">
   <%= favicon_link_tag 'favicon.ico' %>
   <%= stylesheet_link_tag 'ssds', media: 'all' %>
   <%= stylesheet_link_tag 'application', media: 'all' %>


### PR DESCRIPTION
Note: the icon styles are imported in styles.scss so this should reduce
the assets being loaded by the browser twice.