### PR TITLE
Configure rubocop with new cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,12 @@ AllCops:
 Layout/LineLength:
   Max: 120
 
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
 Lint/SuppressedException:
   Enabled: false
 
@@ -85,3 +91,12 @@ Style/StringLiterals:
 
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true


### PR DESCRIPTION
Enable new cops. This will also suppress the warning message when running rubocop.