### PR TITLE
Check whether too many funds are being selected

### DIFF
--- a/app/assets/javascripts/encumbrance_reports.js
+++ b/app/assets/javascripts/encumbrance_reports.js
@@ -1,14 +1,35 @@
 // Place all the behaviors and hooks related to the matching controller here.
 // All this logic will automatically be available in application.js.
 jQuery(document).ready(function($) {
-    $('table').DataTable({
-      "columns": [
-        { "orderable": false },
-        null,
-        null,
-        null,
-        null,
-        null
-      ]
-    });
+  $('table').DataTable({
+    "columns": [
+      { "orderable": false },
+      null,
+      null,
+      null,
+      null,
+      null
+    ]
+  });
+
+  const input_checked = 'input[name="encumbrance_report[fund][]"]';
+  const max_funds = $("div#fundalert").attr('data-max');
+  $(input_checked).click(function() {
+    var checked_funds = $(input_checked + ':checked').length;
+    if (checked_funds > max_funds) {
+      addAlert();
+    } else {
+      removeAlert();
+    }
+  });
 });
+
+function addAlert(){
+  $(".alert").addClass('in').removeClass('out');
+  return false;
+}
+
+function removeAlert(){
+  $(".alert").addClass('out').removeClass('in');
+  return false;
+}

--- a/app/assets/javascripts/expenditure_reports.js
+++ b/app/assets/javascripts/expenditure_reports.js
@@ -1,14 +1,35 @@
 // Place all the behaviors and hooks related to the matching controller here.
 // All this logic will automatically be available in application.js.
 jQuery(document).ready(function($) {
-    $('table').DataTable({
-      "columns": [
-        { "orderable": false },
-        null,
-        null,
-        null,
-        null,
-        null
-      ]
-    });
+  $('table').DataTable({
+    "columns": [
+      { "orderable": false },
+      null,
+      null,
+      null,
+      null,
+      null
+    ]
+  });
+
+  const input_checked = 'input[name="expenditure_report[fund][]"]';
+  const max_funds = $("div#fundalert").attr('data-max');
+  $(input_checked).click(function() {
+    var checked_funds = $(input_checked + ':checked').length;
+    if (checked_funds > max_funds) {
+      addAlert();
+    } else {
+      removeAlert();
+    }
+  });
 });
+
+function addAlert(){
+  $(".alert").addClass('in').removeClass('out');
+  return false;
+}
+
+function removeAlert(){
+  $(".alert").addClass('out').removeClass('in');
+  return false;
+}

--- a/app/models/concerns/fund_utils.rb
+++ b/app/models/concerns/fund_utils.rb
@@ -2,7 +2,7 @@
 # Utilities to chose and/or transform the date range that gets persisted by Expenditure reports.
 # There must be a start date, but the end date is optional and if absent will be set the same as the start date
 ###
-module FundYearUtils
+module FundUtils
   extend ActiveSupport::Concern
 
   def check_dates

--- a/app/models/expenditure_report.rb
+++ b/app/models/expenditure_report.rb
@@ -2,7 +2,7 @@
 # Class to model EXPENDITURES_FUNDS oracle table
 ###
 class ExpenditureReport < ApplicationRecord
-  include FundYearUtils
+  include FundUtils
   attr_accessor :fund, :fund_begin, :fund_select, :date_type, :fy_start, :fy_end,
                 :cal_start, :cal_end, :pd_start, :pd_end, :output_file
 

--- a/app/models/expenditures_with_circ_stats_report.rb
+++ b/app/models/expenditures_with_circ_stats_report.rb
@@ -2,7 +2,7 @@
 # Class to model EXPENDITURES_FUNDS oracle table
 ###
 class ExpendituresWithCircStatsReport < ApplicationRecord
-  include FundYearUtils
+  include FundUtils
   attr_accessor :fund, :fund_begin, :fund_select, :date_type,
                 :fy_start, :fy_end, :cal_start, :cal_end, :pd_start, :pd_end,
                 :lib_array, :libraries, :format_array, :formats

--- a/app/views/shared/_funds_selection.html.erb
+++ b/app/views/shared/_funds_selection.html.erb
@@ -1,3 +1,6 @@
+<div class="text-center alert alert-danger fade out" id="fundalert" data-max="<%= Rails.env.production? ? 55 : 5 %>">
+  <strong>Warning!</strong> Too many individual funds selected. Please select fewer funds.
+</div>
 <div class='form-group row'>
   <%= f.label :fund_select, 'Select funds for report by:', class: 'col-sm-4 form-control-label'%>
   <div class='col-sm-8'>

--- a/db/seeds/test.rb
+++ b/db/seeds/test.rb
@@ -23,6 +23,7 @@ make_table(EdiInvoice, 'edi_invoice.csv', %w[edi_doc_num edi_vend_id edi_vend_in
   uni_inv_key uni_inv_num edi_invc_total uni_invc_total edi_total_postage edi_total_freight edi_total_handling edi_total_insurance
   edi_cur_code edi_total_tax edi_exchg_rate edi_tax_rate edi_total_pieces])
 make_table(EdiLin, 'edi_lin.csv', %w[doc_num vend_id edi_lin_num edi_sublin_count vend_unique_id barcode_num])
+make_table(ExpendituresFunds, 'expenditures_funds.csv', %w[fund_id fund_name_key old_fund_id min_pay_date max_pay_date is_endow inv_lib])
 
 ExpendituresFyDate.destroy_all
 dates = [

--- a/spec/features/expenditure_reports_spec.rb
+++ b/spec/features/expenditure_reports_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Expenditure Reports Page', type: :feature do
+describe 'Expenditure Reports Page', type: :feature, js: true do
   before do
     stub_current_user(FactoryBot.create(:authorized_user))
     visit new_expenditure_report_path
@@ -11,5 +11,20 @@ describe 'Expenditure Reports Page', type: :feature do
     time = Time.zone.parse(attribute)
     now = Time.zone.parse(I18n.l(Time.now.getlocal, format: :oracle))
     expect(time.strftime('%F %R')).to eq now.strftime('%F %R')
+  end
+
+  it 'has a hidden warning message for selecting too many funds' do
+    expect(page.find('div#fundalert', visible: false)).to be_truthy
+  end
+
+  it 'shows the warning message when too many funds are selected' do
+    page.find(:css, 'input#expenditure_report_fund_select_fund_name_id').click
+    within(:css, 'div.table-container') do
+      page.all(:css, 'input[type="checkbox"]').each_with_index { |checkbox, index| checkbox.click if index < 10 }
+    end
+    alert = page.find('div#fundalert',
+                      visible: true,
+                      text: 'Warning! Too many individual funds selected. Please select fewer funds.')
+    expect(alert).to be_truthy
   end
 end


### PR DESCRIPTION
Fixes #728 

Adds some javascript to dynamically check whether too many funds are being selected. Instead of checking the length of the string, and warning the user after they submit the form, since the fund codes are uniformly 17 characters, we can just check the length of the form array and warn the user when they check more funds than oracle can handle: 950 chars/17 =~ 55 funds that can be safely selected.

Also, renaming `FundYearUtils` to just `FundUtils` because not all of the methods deal with dates.