### PR TITLE
Disable rubocop blocklength for packages controller test

### DIFF
--- a/spec/controllers/packages_controller_spec.rb
+++ b/spec/controllers/packages_controller_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 
+# rubocop:disable Metrics/BlockLength
 RSpec.describe PackagesController, type: :controller do
   before do
     stub_current_user(FactoryBot.create(:admin_user))
@@ -131,3 +132,4 @@ RSpec.describe PackagesController, type: :controller do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Build runs but local rubocop fails on blocklength violation.