### PR TITLE
Refactor digital_bookplate

### DIFF
--- a/app/models/digital_bookplate.rb
+++ b/app/models/digital_bookplate.rb
@@ -9,10 +9,16 @@ class DigitalBookplate
   def self.parse_data
     digital_bookplates = []
     TSV.parse_file(Settings.symphony_config_digital_bookplates).without_header.map do |row|
-      hash = { fund: row[0], druid: row[1].gsub(/^druid:/, ''), title: row[3] }
-      hash[:fund] = 'ZZ_NO_FUND' if /[a-z]{2}[0-9]{3}[a-z]{2}[0-9]{4}/.match?(hash[:fund])
-      digital_bookplates.push(hash)
+      digital_bookplates.push(druid_hash(row))
     end
     digital_bookplates
+  end
+
+  def self.druid_hash(row)
+    { fund: row_fund(row[0]), druid: row[1].delete_prefix('druid:'), title: row[3] }
+  end
+
+  def self.row_fund(data)
+    /[a-z]{2}[0-9]{3}[a-z]{2}[0-9]{4}/.match?(data) ? 'ZZ_NO_FUND' : data
   end
 end

--- a/spec/views/digital_bookplates_batches/add_batch.html.erb_spec.rb
+++ b/spec/views/digital_bookplates_batches/add_batch.html.erb_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe 'digital_bookplates_batches/new/add_batch', type: :view do
     assert_select 'h2', text: 'Add digital bookplate metadata to Symphony records'.to_s
   end
 
+  it 'displays bookplate data with no fund names' do
+    assert_select 'table>tbody>tr>td', text: 'ZZ_NO_FUND'.to_s, count: 560
+  end
+
   it 'displays bookplate data in a table' do
     assert_select 'table>tbody>tr>td', text: 'ABBASI'.to_s, count: 1
     assert_select 'table>tbody>tr>td', text: 'rn593kb3193'.to_s, count: 1

--- a/spec/views/digital_bookplates_batches/delete_batch.html.erb_spec.rb
+++ b/spec/views/digital_bookplates_batches/delete_batch.html.erb_spec.rb
@@ -12,7 +12,11 @@ RSpec.describe 'digital_bookplates_batches/new/delete_batch', type: :view do
     assert_select 'h2', text: 'Delete digital bookplate metadata from Symphony records'.to_s
   end
 
-  it 'displays bookplate data in a table' do
+  it 'displays bookplate data with no fund names' do
+    assert_select 'table>tbody>tr>td', text: 'ZZ_NO_FUND'.to_s, count: 560
+  end
+
+  it 'displays bookplate data with fund names' do
     assert_select 'table>tbody>tr>td', text: 'ABBASI'.to_s, count: 1
     assert_select 'table>tbody>tr>td', text: 'rn593kb3193'.to_s, count: 1
     assert_select 'table>tbody>tr>td', text: 'Sohaib and Sara Abbasi Collection'.to_s, count: 1


### PR DESCRIPTION
Rubocop wanted me to use `delete_prefix('druid:')` instead of `gsub`. Also did some refactoring.