### PR TITLE
Use delete instead of destroy

### DIFF
--- a/app/models/uni_updates_batch.rb
+++ b/app/models/uni_updates_batch.rb
@@ -6,7 +6,7 @@ class UniUpdatesBatch < ApplicationRecord
   self.primary_key = 'batch_id'
   has_many :uni_updates, foreign_key: 'batch_id',
                          class_name: 'UniUpdates',
-                         dependent: :destroy,
+                         dependent: :delete_all,
                          inverse_of: :uni_updates_batch
 
   def self.create_item_type_batch(params, total_bcs)

--- a/lib/tasks/webforms.rake
+++ b/lib/tasks/webforms.rake
@@ -134,7 +134,7 @@ namespace :webforms do
   task :delete_batch, [:batch_id] => :environment do |_t, args|
     uni_updates_batch = UniUpdatesBatch.find(args[:batch_id])
     puts "Deleting batch id #{uni_updates_batch.batch_id}"
-    uni_updates_batch.destroy
     WebformsMailer.batch_delete_email(uni_updates_batch).deliver_now
+    uni_updates_batch.destroy
   end
 end

--- a/spec/controllers/uni_updates_batches_controller_spec.rb
+++ b/spec/controllers/uni_updates_batches_controller_spec.rb
@@ -12,15 +12,22 @@ RSpec.describe UniUpdatesBatchesController, type: :controller do
   end
 
   describe 'DELETE#destroy' do
-    before { @uni_updates_batch = FactoryBot.create(:uni_updates_batch) }
+    before do
+      stub_current_user(FactoryBot.create(:authorized_user))
+      @uni_updates_batch = FactoryBot.create(:uni_updates_batch)
+      FactoryBot.create(:uni_updates)
+    end
 
     it 'deletes the contact' do
-      stub_current_user(FactoryBot.create(:authorized_user))
       expect { delete :destroy, params: { id: @uni_updates_batch } }.to change(UniUpdatesBatch, :count).by(-1)
     end
 
+    it 'removes the associated uni_updates' do
+      delete :destroy, params: { id: @uni_updates_batch }
+      expect(UniUpdates.count).to eq 0
+    end
+
     it 'redirects to root_path' do
-      stub_current_user(FactoryBot.create(:authorized_user))
       delete :destroy, params: { id: @uni_updates_batch }
       expect(response).to redirect_to root_path
     end


### PR DESCRIPTION
See: https://medium.com/@wkhearn/delete-vs-destroy-does-it-even-matter-8cb4db6aa660:
"`The easiest way to sum it up is to use delete if you want records to be deleted quickly. However, if you care about models callbacks, referential integrity, or validations (for example, setting a criteria to not destroy a record unless a certain condition is “true”), then use destroy.`"

The problem was with the removing of the associated UniUpdates rows. Changing it to `delete_all` because there are no callbacks or references on the dependent model.

