### PR TITLE
Allow empty blocks in tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,9 @@ AllCops:
 Layout/LineLength:
   Max: 120
 
+Lint/EmptyBlock:
+  Enabled: false
+
 Lint/SuppressedException:
   Enabled: false
 

--- a/spec/views/home/index.html.erb_spec.rb
+++ b/spec/views/home/index.html.erb_spec.rb
@@ -19,8 +19,8 @@ describe 'home/index', type: :view do
 
   describe 'non-authorized user' do
     before do
-      stub_current_user_for_view {}
-      stub_user_id_for_view {}
+      stub_current_user_for_view { FactoryBot.create(:blank_user) }
+      stub_user_id_for_view { FactoryBot.create(:blank_user) }
       render
     end
 


### PR DESCRIPTION
After upgrading rubocop there is a new lint to be handled.