### PR TITLE
Rubocop ignore EmptyClass Lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,9 @@ Layout/LineLength:
 Lint/EmptyBlock:
   Enabled: false
 
+Lint/EmptyClass:
+  Enabled: false
+
 Lint/SuppressedException:
   Enabled: false
 


### PR DESCRIPTION
The Ability class will error if there is no class defined (i.e. the class file is removed).