### PR TITLE
Fixes edi_lin_update_barcode params not being sent to controller

### DIFF
--- a/app/controllers/edi_lins_controller.rb
+++ b/app/controllers/edi_lins_controller.rb
@@ -48,12 +48,13 @@ class EdiLinsController < ApplicationController
   end
 
   def update_barcode
-    @barcode_result = EdiLin.update_barcode(params[:vend_id],
-                                            params[:doc_num],
-                                            params[:edi_lin_num],
-                                            params[:edi_sublin_count],
-                                            params[:old_barcode],
-                                            params[:new_barcode])
+    @barcode_result = EdiLin.update_barcode(params[:edi_lin][:vend_id],
+                                            params[:edi_lin][:doc_num],
+                                            params[:edi_lin][:edi_lin_num],
+                                            params[:edi_lin][:edi_sublin_count],
+                                            params[:edi_lin][:old_barcode],
+                                            params[:edi_lin][:new_barcode])
+
     flash[@barcode_result[0].to_sym] = @barcode_result[1]
     redirect_to edi_invoices_menu_path
   end

--- a/app/models/edi_lin.rb
+++ b/app/models/edi_lin.rb
@@ -2,6 +2,8 @@
 class EdiLin < ApplicationRecord
   self.table_name = 'edi_lin'
 
+  attr_accessor :new_barcode
+
   def self.primary_key
     row_id
   end

--- a/app/views/edi_lins/edit.html.erb
+++ b/app/views/edi_lins/edit.html.erb
@@ -10,16 +10,21 @@
     </tr>
     </thead>
     <tbody>
-    <% @edi_lin.each do |edi, index | %>
-      <tr class='<%= cycle("odd", "even") %>'>
-        <td><%= edi.vend_id %></td>
-        <td><%= edi.doc_num %></td>
-        <td><%= edi.edi_lin_num.present? ? edi.edi_lin_num.to_i : '' %></td>
-        <td><%= text_field_tag('new_barcode', '', placeholder: edi.barcode_num.present? ? edi.barcode_num.to_i : '', onblur: "$('#barcode#{index}').data('bc', $(this).val())") %></td>
-        <td>
-          <%= link_to 'Change this barcode', {controller: 'edi_lins', action: 'update_barcode'}, id: "barcode#{index}", onclick: "window.location = '/edi_lins/update_barcode?new_barcode=' + $('#barcode#{index}').data('bc') + '&vend_id=#{edi.vend_id}&doc_num=#{edi.doc_num}&edi_lin_num=#{edi.edi_lin_num}&edi_sublin_count=#{edi.edi_sublin_count}&old_barcode=#{edi.barcode_num}'; return true" , class: 'btn btn-primary' %>
-        </td>
-      </tr>
+    <% @edi_lin.each do |edi, index| %>
+      <%= form_for edi, :url => { :action => 'update_barcode' }, class: 'form-group' do |f| %>
+        <tr class='<%= cycle('odd', 'even') %>'>
+          <td><%= edi.vend_id %></td>
+          <td><%= edi.doc_num %></td>
+          <td><%= edi.edi_lin_num.present? ? edi.edi_lin_num.to_i : '' %></td>
+          <td><%= f.text_field :new_barcode %></td>
+        </tr>
+        <%= f.hidden_field :doc_num, value: edi.doc_num %>
+        <%= f.hidden_field :vend_id, value: edi.vend_id %>
+        <%= f.hidden_field :edi_lin_num, value: edi.edi_lin_num %>
+        <%= f.hidden_field :edi_sublin_count, value: edi.edi_sublin_count %>
+        <%= f.hidden_field :old_barcode, value: edi.barcode_num %>
+        <td><%= f.submit 'Change this barcode', class:'btn btn-primary' %></td>
+      <% end %>
     <% end %>
     </tbody>
   </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,8 +71,8 @@ Rails.application.routes.draw do
   get 'edi_lins/fix_duplicate_barcode' => 'edi_lins#fix_duplicate_barcode'
   get 'edi_lins/index' => 'edi_lins#index'
   get 'edi_lins/update_edi_lin' => 'edi_lins#update_edi_lin'
-  get 'edi_lins/update_barcode' => 'edi_lins#update_barcode'
   get 'edi_lins/show/:barcode_num' => 'edi_lins#show'
+  patch 'edi_lins/update_barcode' => 'edi_lins#update_barcode'
 
   resources :lobbytrack_reports, only: [:index]
   post 'lobbytrack_reports/visits' => 'lobbytrack_reports#visits'

--- a/spec/controllers/edi_lins_controller_spec.rb
+++ b/spec/controllers/edi_lins_controller_spec.rb
@@ -106,10 +106,10 @@ RSpec.describe EdiLinsController, type: :controller do
     end
 
     let(:message) do
-      get 'update_barcode', params: { new_barcode: '11111111111111',
-                                      vend_id: 'AMALIV', doc_num: '592924',
-                                      edi_lin_num: 1, edi_sublin_count: 0,
-                                      old_barcode: '99999999999999' }
+      patch 'update_barcode', params: { edi_lin:
+                                          { new_barcode: '11111111111111', vend_id: 'AMALIV',
+                                            doc_num: '592924', edi_lin_num: 1, edi_sublin_count: 0,
+                                            old_barcode: '99999999999999' } }
     end
 
     before do


### PR DESCRIPTION
Fixes #875 

Previously I was trying to use a javascript onclick event to change the window location to the edi_lin controller path with params, but the params were not being passed because the rails `link_to` helper was overriding the change in page navigation. I changed the view to do a form submission using the `form_for` helper which I should have done to begin with. Not sure what I was thinking before when I wrote this....¯\_(ツ)_/¯ 