### PR TITLE
Make sure edi_lin_num is a positive number and not a string

### DIFF
--- a/app/models/edi_lin.rb
+++ b/app/models/edi_lin.rb
@@ -13,7 +13,7 @@ class EdiLin < ApplicationRecord
   end
 
   def self.update_edi_lin(vendor, invoice, line)
-    return ['error', 'Line number must be an integer'] unless line.is_a? Integer
+    return ['error', 'Line number must be an integer'] unless line.to_i.positive?
 
     edi_lin = where('vend_id = ? AND doc_num = ? AND edi_lin_num = ? AND edi_sublin_count = 0', vendor, invoice, line)
     if ids_match?(EdiSumrzBib.id(edi_lin.vend_unique_id), edi_lin.vend_unique_id)

--- a/app/views/edi_lins/_allow_nobib.html.erb
+++ b/app/views/edi_lins/_allow_nobib.html.erb
@@ -25,7 +25,7 @@
           <%= text_field_tag 'invoice_number' %>
         </div>
         <div class="div-table-cell">
-          <%= text_field_tag 'invoice_line_number' %>
+          <%= number_field_tag 'invoice_line_number' %>
         </div>
       </div>
     </div>

--- a/spec/models/package_spec.rb
+++ b/spec/models/package_spec.rb
@@ -110,11 +110,13 @@ RSpec.describe Package, type: :model do
     end
 
     it 'date entered has a value' do
-      expect(@package.date_entered).to eq Time.zone.parse(I18n.l(Time.now.getlocal, format: :oracle))
+      expect(@package.date_entered.strftime('%T'))
+        .to eq Time.zone.parse(I18n.l(Time.now.getlocal, format: :oracle)).strftime('%T')
     end
 
     it 'date modified is updated' do
-      expect(@package.date_modified).to eq Time.zone.parse(I18n.l(Time.now.getlocal, format: :oracle))
+      expect(@package.date_modified.strftime('%T'))
+        .to eq Time.zone.parse(I18n.l(Time.now.getlocal, format: :oracle)).strftime('%T')
     end
   end
 end


### PR DESCRIPTION
The input field should be a number field instead of a text field, but also Instead of checking whether the input is an integer, just make sure it is a positive integer.

Also, some tests were failing because the time stamp comes out different if the test takes too long to run. So just check for the hour and minutes (using `strftime('%T')`) and ignore the seconds in the test.